### PR TITLE
feat(project-details): add client and developer people panel

### DIFF
--- a/src/components/templates/ProjectDetailsTemplate.tsx
+++ b/src/components/templates/ProjectDetailsTemplate.tsx
@@ -248,6 +248,37 @@ export const ProjectDetailsTemplate = ({
                 )}
               </div>
 
+              {/* People */}
+              <div className='w-[300px] space-y-4'>
+                {([
+                  { label: 'CLIENT', user: project.client },
+                  { label: 'DEVELOPER', user: project.developer },
+                ] as const).map(({ label, user }) => {
+                  const initials = user
+                    ? (`${user.firstName?.[0] ?? ''}${user.lastName?.[0] ?? ''}`
+                        .toUpperCase() || '?')
+                    : null
+                  const fullName = user
+                    ? ([user.firstName, user.lastName].filter(Boolean).join(' ') || user.email)
+                    : null
+                  return (
+                    <div key={label} className='flex items-center gap-3'>
+                      <span className='w-20 font-mono text-xs text-green-400/50'>{label}</span>
+                      {user ? (
+                        <>
+                          <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-green-400/20 bg-green-400/10 font-mono text-xs text-green-400'>
+                            {initials}
+                          </div>
+                          <span className='font-mono text-sm text-green-300'>{fullName}</span>
+                        </>
+                      ) : (
+                        <span className='font-mono text-sm text-green-400/40'>UNASSIGNED</span>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+
               {/* Status Badge */}
               <div className='text-center'>
                 <span


### PR DESCRIPTION
## Summary
- Adds a people block to the left column of `ProjectDetailsTemplate`, between the logo and the status badge
- Shows CLIENT and DEVELOPER rows with initials avatar circle and full name; shows UNASSIGNED if no developer is set
- Width constrained to 300px to align with the logo's left edge
- No new component, no permission gating — visible to all users
- No GraphQL changes needed; uses `project.client` and `project.developer` already fetched via `UserDisplay` fragment

## Test plan
- [ ] Visit a project details page as guest, client, and admin — people panel is visible in all cases
- [ ] Project with no assigned developer shows UNASSIGNED
- [ ] Initials, full name, and avatar circle render correctly
- [ ] Panel left-aligns with the logo above it

🤖 Generated with [Claude Code](https://claude.com/claude-code)