### PR TITLE
perf(landing): lazy-load MatrixBackground after FCP

### DIFF
--- a/src/components/templates/LandingPageTemplate.tsx
+++ b/src/components/templates/LandingPageTemplate.tsx
@@ -1,6 +1,11 @@
 'use client'
 
-import { MatrixBackground } from '@/components/atoms'
+import dynamic from 'next/dynamic'
+
+const MatrixBackground = dynamic(
+  () => import('@/components/atoms').then((m) => ({ default: m.MatrixBackground })),
+  { ssr: false }
+)
 
 type LandingPageTemplateProps = {
   children: React.ReactNode


### PR DESCRIPTION
## Summary

- Converts `MatrixBackground` in `LandingPageTemplate` from a static import to a `next/dynamic` import with `ssr: false`
- The canvas animation now loads only after initial paint instead of blocking it
- Addresses one of the primary causes of FCP > 3s on the landing page

## Test plan

- [ ] Visit the landing page and confirm the matrix animation still appears
- [ ] Check DevTools > Performance / Lighthouse — FCP should improve
- [ ] Confirm no SSR errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized landing page background component loading for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->