### PR TITLE
perf(layout): extract ClientProviders and set apollo fetchPolicy to cache-first

### DIFF
--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -3,54 +3,21 @@ import { describe, expect, it, vi } from 'vitest'
 
 import RootLayout from './layout'
 
-// Mock Next.js components
-vi.mock('next/font/google', () => ({
-  Inter: () => ({ className: 'inter-font' }),
-}))
-
-// Mock providers
 vi.mock('@/providers', () => ({
-  ClerkProvider: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid='clerk-provider'>{children}</div>
-  ),
-  QueryProvider: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid='query-provider'>{children}</div>
-  ),
-}))
-
-// Mock analytics
-vi.mock('@/analytics', () => ({
-  PostHogProvider: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid='posthog-provider'>{children}</div>
-  ),
-  PostHogPageView: () => <div data-testid='posthog-pageview' />,
-}))
-
-// Mock Apollo Client
-vi.mock('@apollo/client', () => ({
-  HttpLink: vi.fn(),
-  InMemoryCache: vi.fn(),
-  ApolloClient: vi.fn(),
-}))
-
-vi.mock('@apollo/client/react', () => ({
-  ApolloProvider: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid='apollo-provider'>{children}</div>
+  ClientProviders: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid='client-providers'>{children}</div>
   ),
 }))
 
 describe('RootLayout', () => {
-  it('should render with all providers', () => {
+  it('should render with providers', () => {
     render(
       <RootLayout>
         <div data-testid='page-content'>Page Content</div>
       </RootLayout>
     )
 
-    expect(screen.getByTestId('clerk-provider')).toBeInTheDocument()
-    expect(screen.getByTestId('posthog-provider')).toBeInTheDocument()
-    expect(screen.getByTestId('apollo-provider')).toBeInTheDocument()
-    expect(screen.getByTestId('query-provider')).toBeInTheDocument()
+    expect(screen.getByTestId('client-providers')).toBeInTheDocument()
     expect(screen.getByTestId('page-content')).toBeInTheDocument()
   })
 
@@ -61,7 +28,6 @@ describe('RootLayout', () => {
       </RootLayout>
     )
 
-    // Check that the html element exists and has the correct structure
     expect(document.documentElement.tagName).toBe('HTML')
     expect(document.documentElement.getAttribute('lang')).toBe('en')
     expect(document.body).toBeInTheDocument()

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,36 +1,19 @@
-'use client'
-
-import { ApolloProvider } from '@apollo/client/react'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 
-import { PostHogProvider } from '@/analytics'
-import { ToastContainer } from '@/components/atoms'
-import { apolloClient } from '@/libs/ApolloClient'
-import { ClerkProvider, QueryProvider } from '@/providers'
+import { ClientProviders } from '@/providers'
 import '@/styles/global.css'
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  return (
-    <html lang='en'>
-      <body>
-        <ClerkProvider>
-          <PostHogProvider>
-            <ApolloProvider client={apolloClient}>
-              <QueryProvider>
-                {children}
-                <ToastContainer />
-                <Analytics />
-                <SpeedInsights />
-              </QueryProvider>
-            </ApolloProvider>
-          </PostHogProvider>
-        </ClerkProvider>
-      </body>
-    </html>
-  )
-}
+const RootLayout = ({ children }: { children: React.ReactNode }) => (
+  <html lang='en'>
+    <body>
+      <ClientProviders>
+        {children}
+      </ClientProviders>
+      <Analytics />
+      <SpeedInsights />
+    </body>
+  </html>
+)
+
+export default RootLayout

--- a/src/libs/ApolloClient.ts
+++ b/src/libs/ApolloClient.ts
@@ -34,7 +34,7 @@ export const apolloClient = new ApolloClient({
       fetchPolicy: 'cache-and-network',
     },
     query: {
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'cache-first',
     },
   },
 })

--- a/src/providers/ClientProviders.tsx
+++ b/src/providers/ClientProviders.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { ApolloProvider } from '@apollo/client/react'
+
+import { PostHogProvider } from '@/analytics'
+import { ToastContainer } from '@/components/atoms'
+import { apolloClient } from '@/libs/ApolloClient'
+
+import { ClerkProvider } from './ClerkProvider'
+import { QueryProvider } from './QueryProvider'
+
+export const ClientProviders = ({ children }: { children: React.ReactNode }) => (
+  <ClerkProvider>
+    <PostHogProvider>
+      <ApolloProvider client={apolloClient}>
+        <QueryProvider>
+          {children}
+          <ToastContainer />
+        </QueryProvider>
+      </ApolloProvider>
+    </PostHogProvider>
+  </ClerkProvider>
+)

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,2 +1,3 @@
 export { ClerkProvider } from './ClerkProvider'
+export { ClientProviders } from './ClientProviders'
 export { QueryProvider } from './QueryProvider'

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,3 +1,1 @@
-export { ClerkProvider } from './ClerkProvider'
 export { ClientProviders } from './ClientProviders'
-export { QueryProvider } from './QueryProvider'


### PR DESCRIPTION
## Summary

- Extract all client-only providers (`ClerkProvider`, `PostHogProvider`, `ApolloProvider`, `QueryProvider`, `ToastContainer`) into a new `src/providers/ClientProviders.tsx` (`'use client'`), allowing the root layout to be a server component
- Change Apollo `query.fetchPolicy` from `network-only` to `cache-first` to stop blocking FCP while waiting on GraphQL round-trips

## Test plan

- [ ] App loads and all providers work (auth, analytics, queries, toasts)
- [ ] No hydration errors in console
- [ ] FCP measurably faster on GraphQL pages (check Vercel Speed Insights)

🤖 Generated with [Claude Code](https://claude.com/claude-code)