### PR TITLE
perf(providers): lazy-load PostHog to defer analytics bundle after FCP

### DIFF
--- a/src/providers/ClientProviders.tsx
+++ b/src/providers/ClientProviders.tsx
@@ -1,13 +1,18 @@
 'use client'
 
 import { ApolloProvider } from '@apollo/client/react'
+import dynamic from 'next/dynamic'
 
-import { PostHogProvider } from '@/analytics'
 import { ToastContainer } from '@/components/atoms'
 import { apolloClient } from '@/libs/ApolloClient'
 
 import { ClerkProvider } from './ClerkProvider'
 import { QueryProvider } from './QueryProvider'
+
+const PostHogProvider = dynamic(
+  () => import('@/analytics').then((m) => m.PostHogProvider),
+  { ssr: false, loading: () => null }
+)
 
 export const ClientProviders = ({ children }: { children: React.ReactNode }) => (
   <ClerkProvider>


### PR DESCRIPTION
## Summary

- Replaces static `PostHogProvider` import with `next/dynamic` using `{ ssr: false }`
- PostHog's JS bundle is now split into a separate chunk, loaded client-side only after initial render
- `loading: () => null` ensures no placeholder UI while the chunk loads

## Why

PostHog is pure analytics — it has no effect on what the user sees. Loading it statically was including it in the critical bundle and blocking/delaying FCP. Deferring it removes that cost entirely from the initial render path.

## Test plan

- [ ] Verify PostHog events still fire in the browser after page load
- [ ] Confirm no SSR errors in server logs
- [ ] Check Network tab: PostHog chunk loads after main bundle, not blocking FCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized application provider initialization to improve startup performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->