### PR TITLE
fix(dashboard): route view request to dedicated project request detail page

### DIFF
--- a/src/apiClients/projectRequestApiClient.ts
+++ b/src/apiClients/projectRequestApiClient.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@apollo/client/react'
+import { useMutation, useQuery } from '@apollo/client/react'
 import { gql } from 'graphql-tag'
 
 import type {
@@ -6,6 +6,8 @@ import type {
   ApproveProjectRequestMutationVariables,
   CreateProjectRequestMutation,
   CreateProjectRequestMutationVariables,
+  GetProjectRequestByIdQuery,
+  GetProjectRequestByIdQueryVariables,
   GetProjectRequestsQuery,
 } from '@/graphql/generated/graphql'
 
@@ -23,6 +25,15 @@ import { PROJECT_REQUEST_DISPLAY_FRAGMENT } from './fragments'
 export const GET_PROJECT_REQUESTS = gql`
   query GetProjectRequests {
     projectRequests {
+      ...ProjectRequestDisplay
+    }
+  }
+  ${PROJECT_REQUEST_DISPLAY_FRAGMENT}
+`
+
+export const GET_PROJECT_REQUEST_BY_ID = gql`
+  query GetProjectRequestById($id: ID!) {
+    projectRequest(id: $id) {
       ...ProjectRequestDisplay
     }
   }
@@ -74,6 +85,11 @@ export const UPDATE_PROJECT_REQUEST_STATUS = gql`
 
 // Hooks for components
 export const useGetProjectRequests = () => useGetProjectRequestsQuery()
+export const useGetProjectRequestById = (id: string) =>
+  useQuery<GetProjectRequestByIdQuery, GetProjectRequestByIdQueryVariables>(
+    GET_PROJECT_REQUEST_BY_ID,
+    { variables: { id } }
+  )
 export const useCreateProjectRequest = () => useCreateProjectRequestMutation()
 export const useApproveProjectRequest = () =>
   useMutation(APPROVE_PROJECT_REQUEST)

--- a/src/app/(auth)/dashboard/project-requests/[id]/ProjectRequestDetail.tsx
+++ b/src/app/(auth)/dashboard/project-requests/[id]/ProjectRequestDetail.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import Link from 'next/link'
+
+import { useGetProjectRequestById } from '@/apiClients/projectRequestApiClient'
+import { RequirementsList } from '@/components/molecules'
+import { formatCardDate } from '@/utils'
+import { formatStatus, getStatusCardStyling } from '@/utils/Project'
+
+type ProjectRequestDetailProps = {
+  id: string
+}
+
+export const ProjectRequestDetail = ({ id }: ProjectRequestDetailProps) => {
+  const { data, loading, error } = useGetProjectRequestById(id)
+
+  if (loading) {
+    return (
+      <div className='py-20 text-center font-mono text-green-400/60'>
+        Loading...
+      </div>
+    )
+  }
+
+  if (error || !data?.projectRequest) {
+    return (
+      <div className='py-20 text-center font-mono text-red-400/60'>
+        Request not found.{' '}
+        <Link
+          href='/dashboard'
+          className='text-green-400 underline hover:text-green-300'
+        >
+          Back to dashboard
+        </Link>
+      </div>
+    )
+  }
+
+  const request = data.projectRequest
+  const status = request.status || 'unknown'
+
+  return (
+    <div className='mx-auto max-w-3xl'>
+      {/* Header */}
+      <div className='mb-8 flex items-start justify-between gap-4'>
+        <div>
+          <h1 className='font-mono text-2xl font-bold text-green-400'>
+            {request.title || request.projectName}
+          </h1>
+          <p className='mt-1 font-mono text-sm tracking-wide text-green-300/60 uppercase'>
+            {(request.projectType || 'unknown').replace('_', ' ')}
+          </p>
+        </div>
+        <span
+          className={`rounded border px-3 py-1 font-mono text-xs font-bold whitespace-nowrap uppercase ${getStatusCardStyling(status)}`}
+        >
+          {formatStatus(status)}
+        </span>
+      </div>
+
+      <div className='space-y-6'>
+        {/* Meta */}
+        <div className='grid grid-cols-2 gap-4 rounded-lg border border-green-400/20 bg-black/60 p-4'>
+          {request.budget && (
+            <div>
+              <p className='font-mono text-xs text-green-300/60 uppercase'>
+                Budget
+              </p>
+              <p className='font-mono text-sm text-green-300'>
+                ${request.budget.toLocaleString()}
+              </p>
+            </div>
+          )}
+          {request.timeline && (
+            <div>
+              <p className='font-mono text-xs text-green-300/60 uppercase'>
+                Timeline
+              </p>
+              <p className='font-mono text-sm text-green-300'>
+                {request.timeline}
+              </p>
+            </div>
+          )}
+          <div>
+            <p className='font-mono text-xs text-green-300/60 uppercase'>
+              Submitted
+            </p>
+            <p className='font-mono text-sm text-green-300'>
+              {formatCardDate(request.createdAt)}
+            </p>
+          </div>
+        </div>
+
+        {/* Description */}
+        <div className='rounded-lg border border-green-400/20 bg-black/60 p-4'>
+          <h2 className='mb-2 font-mono text-sm font-bold text-green-300'>
+            Description
+          </h2>
+          <p className='font-mono text-sm text-green-300/80'>
+            {request.description}
+          </p>
+        </div>
+
+        {/* Requirements */}
+        {request.requirements && (
+          <div className='rounded-lg border border-green-400/20 bg-black/60 p-4'>
+            <h2 className='mb-2 font-mono text-sm font-bold text-green-300'>
+              Requirements
+            </h2>
+            <RequirementsList requirements={request.requirements} />
+          </div>
+        )}
+
+        {/* Additional Info */}
+        {request.additionalInfo && (
+          <div className='rounded-lg border border-green-400/20 bg-black/60 p-4'>
+            <h2 className='mb-2 font-mono text-sm font-bold text-green-300'>
+              Additional Info
+            </h2>
+            <p className='font-mono text-sm text-green-300/80'>
+              {request.additionalInfo}
+            </p>
+          </div>
+        )}
+
+        {/* Status Updates */}
+        {request.statusUpdates && request.statusUpdates.length > 0 && (
+          <div className='rounded-lg border border-green-400/20 bg-black/60 p-4'>
+            <h2 className='mb-3 font-mono text-sm font-bold text-green-300'>
+              Updates
+            </h2>
+            <div className='space-y-3'>
+              {request.statusUpdates.map((update) => (
+                <div
+                  key={update.id}
+                  className='border-l-2 border-green-400/30 pl-3'
+                >
+                  <div className='flex items-center gap-2'>
+                    <span
+                      className={`rounded border px-2 py-0.5 font-mono text-xs font-bold uppercase ${getStatusCardStyling(update.newStatus || 'unknown')}`}
+                    >
+                      {formatStatus(update.newStatus || 'unknown')}
+                    </span>
+                    <span className='font-mono text-xs text-green-300/50'>
+                      {formatCardDate(update.createdAt)}
+                    </span>
+                  </div>
+                  {update.updateMessage && (
+                    <p className='mt-1 font-mono text-xs text-green-300/70'>
+                      {update.updateMessage}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(auth)/dashboard/project-requests/[id]/page.tsx
+++ b/src/app/(auth)/dashboard/project-requests/[id]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from 'next'
 
-import { AnimatedHeading } from '@/components/molecules'
+import { AnimatedHeading, ProjectRequestDetail  } from '@/components/molecules'
 import { CleanPageTemplate } from '@/components/templates'
 import { BRAND_NAME } from '@/constants'
 
-import { ProjectRequestDetail } from './ProjectRequestDetail'
+
 
 export const metadata: Metadata = {
   title: `Project Request - ${BRAND_NAME}`,

--- a/src/app/(auth)/dashboard/project-requests/[id]/page.tsx
+++ b/src/app/(auth)/dashboard/project-requests/[id]/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from 'next'
+
+import { AnimatedHeading } from '@/components/molecules'
+import { CleanPageTemplate } from '@/components/templates'
+import { BRAND_NAME } from '@/constants'
+
+import { ProjectRequestDetail } from './ProjectRequestDetail'
+
+export const metadata: Metadata = {
+  title: `Project Request - ${BRAND_NAME}`,
+}
+
+type PageProps = {
+  params: Promise<{ id: string }>
+}
+
+const ProjectRequestPage = async ({ params }: PageProps) => {
+  const { id } = await params
+
+  return (
+    <CleanPageTemplate>
+      <div className='container mx-auto px-4'>
+        <div className='mx-auto max-w-4xl'>
+          <div className='mb-12 text-center'>
+            <AnimatedHeading
+              text='PROJECT REQUEST'
+              level='h1'
+              variant='section'
+              className='mb-4'
+            />
+          </div>
+
+          <ProjectRequestDetail id={id} />
+        </div>
+      </div>
+    </CleanPageTemplate>
+  )
+}
+
+export default ProjectRequestPage

--- a/src/components/molecules/project-card/ProjectStatusCard.test.tsx
+++ b/src/components/molecules/project-card/ProjectStatusCard.test.tsx
@@ -142,7 +142,7 @@ describe('ProjectStatusCard', () => {
     expect(viewLink).toBeInTheDocument()
     expect(viewLink.closest('a')).toHaveAttribute(
       'href',
-      '/projects/test-request'
+      '/dashboard/project-requests/1'
     )
   })
 

--- a/src/components/molecules/project-card/ProjectStatusCard.tsx
+++ b/src/components/molecules/project-card/ProjectStatusCard.tsx
@@ -173,7 +173,11 @@ export const ProjectStatusCard = ({ item }: ProjectStatusCardProps) => {
       {/* Action Links */}
       <div className='mb-3 flex flex-wrap gap-2'>
         <Link
-          href={`/projects/${generateSlug(item.projectName || item.title || 'untitled')}`}
+          href={
+            item.__typename === 'Project'
+              ? `/projects/${generateSlug(item.projectName || item.title || 'untitled')}`
+              : `/dashboard/project-requests/${item.id}`
+          }
           className='min-w-0 flex-1 cursor-pointer rounded border border-green-400/30 bg-green-400/5 px-3 py-2 text-center font-mono text-xs text-green-400/60 transition-all duration-300 hover:border-green-400/50 hover:bg-green-400/20 hover:text-green-400'
         >
           {item.__typename === 'Project' ? 'VIEW DETAILS' : 'VIEW REQUEST'}

--- a/src/components/molecules/project-request/ProjectRequestDetail.test.tsx
+++ b/src/components/molecules/project-request/ProjectRequestDetail.test.tsx
@@ -1,0 +1,207 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useGetProjectRequestById } from '@/apiClients/projectRequestApiClient'
+import { ProjectStatus, ProjectType } from '@/graphql/generated/graphql'
+import { createMockProjectRequest } from '@/tests/mocks'
+
+import { ProjectRequestDetail } from './ProjectRequestDetail'
+
+vi.mock('@/apiClients/projectRequestApiClient', () => ({
+  useGetProjectRequestById: vi.fn(),
+}))
+
+vi.mock('./RequirementsList', () => ({
+  RequirementsList: () => <div data-testid='requirements-list' />,
+}))
+
+const mockUseGetProjectRequestById = vi.mocked(useGetProjectRequestById)
+
+const mockRequest = createMockProjectRequest({
+  id: '1',
+  title: 'My Website',
+  projectName: 'my-website',
+  description: 'A personal portfolio site',
+  projectType: ProjectType.WebApp,
+  budget: 2500,
+  timeline: '6 weeks',
+  additionalInfo: 'Prefer dark theme',
+  status: ProjectStatus.InReview,
+  requirements: { __typename: 'ProjectRequirements', hasDesign: true },
+  statusUpdates: [
+    {
+      __typename: 'StatusUpdate',
+      id: 'su-1',
+      newStatus: ProjectStatus.InReview,
+      updateMessage: 'We are reviewing your request',
+      createdAt: '2024-02-01T00:00:00Z',
+    },
+  ],
+})
+
+describe('ProjectRequestDetail', () => {
+  it('renders loading state', () => {
+    mockUseGetProjectRequestById.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    } as ReturnType<typeof useGetProjectRequestById>)
+
+    render(<ProjectRequestDetail id='1' />)
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('renders error state with back link when request not found', () => {
+    mockUseGetProjectRequestById.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: new Error('Not found'),
+    } as ReturnType<typeof useGetProjectRequestById>)
+
+    render(<ProjectRequestDetail id='1' />)
+
+    expect(screen.getByText(/request not found/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /back to dashboard/i })).toHaveAttribute(
+      'href',
+      '/dashboard'
+    )
+  })
+
+  it('renders error state when data is missing', () => {
+    mockUseGetProjectRequestById.mockReturnValue({
+      data: { projectRequest: null },
+      loading: false,
+      error: undefined,
+    } as ReturnType<typeof useGetProjectRequestById>)
+
+    render(<ProjectRequestDetail id='1' />)
+
+    expect(screen.getByText(/request not found/i)).toBeInTheDocument()
+  })
+
+  it('renders project request title and type', () => {
+    mockUseGetProjectRequestById.mockReturnValue({
+      data: { projectRequest: mockRequest },
+      loading: false,
+      error: undefined,
+    } as ReturnType<typeof useGetProjectRequestById>)
+
+    render(<ProjectRequestDetail id='1' />)
+
+    expect(screen.getByText('My Website')).toBeInTheDocument()
+    expect(screen.getByText('WebApp')).toBeInTheDocument()
+  })
+
+  it('renders budget and timeline', () => {
+    mockUseGetProjectRequestById.mockReturnValue({
+      data: { projectRequest: mockRequest },
+      loading: false,
+      error: undefined,
+    } as ReturnType<typeof useGetProjectRequestById>)
+
+    render(<ProjectRequestDetail id='1' />)
+
+    expect(screen.getByText('$2,500')).toBeInTheDocument()
+    expect(screen.getByText('6 weeks')).toBeInTheDocument()
+  })
+
+  it('renders description', () => {
+    mockUseGetProjectRequestById.mockReturnValue({
+      data: { projectRequest: mockRequest },
+      loading: false,
+      error: undefined,
+    } as ReturnType<typeof useGetProjectRequestById>)
+
+    render(<ProjectRequestDetail id='1' />)
+
+    expect(screen.getByText('A personal portfolio site')).toBeInTheDocument()
+  })
+
+  it('renders requirements section when requirements exist', () => {
+    mockUseGetProjectRequestById.mockReturnValue({
+      data: { projectRequest: mockRequest },
+      loading: false,
+      error: undefined,
+    } as ReturnType<typeof useGetProjectRequestById>)
+
+    render(<ProjectRequestDetail id='1' />)
+
+    expect(screen.getByTestId('requirements-list')).toBeInTheDocument()
+  })
+
+  it('renders additional info when present', () => {
+    mockUseGetProjectRequestById.mockReturnValue({
+      data: { projectRequest: mockRequest },
+      loading: false,
+      error: undefined,
+    } as ReturnType<typeof useGetProjectRequestById>)
+
+    render(<ProjectRequestDetail id='1' />)
+
+    expect(screen.getByText('Prefer dark theme')).toBeInTheDocument()
+  })
+
+  it('renders status updates', () => {
+    mockUseGetProjectRequestById.mockReturnValue({
+      data: { projectRequest: mockRequest },
+      loading: false,
+      error: undefined,
+    } as ReturnType<typeof useGetProjectRequestById>)
+
+    render(<ProjectRequestDetail id='1' />)
+
+    expect(
+      screen.getByText('We are reviewing your request')
+    ).toBeInTheDocument()
+  })
+
+  it('omits additional info section when not present', () => {
+    const requestWithoutInfo = createMockProjectRequest({
+      ...mockRequest,
+      additionalInfo: null,
+    })
+    mockUseGetProjectRequestById.mockReturnValue({
+      data: { projectRequest: requestWithoutInfo },
+      loading: false,
+      error: undefined,
+    } as ReturnType<typeof useGetProjectRequestById>)
+
+    render(<ProjectRequestDetail id='1' />)
+
+    expect(screen.queryByText('Additional Info')).not.toBeInTheDocument()
+  })
+
+  it('omits status updates section when empty', () => {
+    const requestWithoutUpdates = createMockProjectRequest({
+      ...mockRequest,
+      statusUpdates: [],
+    })
+    mockUseGetProjectRequestById.mockReturnValue({
+      data: { projectRequest: requestWithoutUpdates },
+      loading: false,
+      error: undefined,
+    } as ReturnType<typeof useGetProjectRequestById>)
+
+    render(<ProjectRequestDetail id='1' />)
+
+    expect(screen.queryByText('Updates')).not.toBeInTheDocument()
+  })
+
+  it('falls back to projectName when title is absent', () => {
+    const requestWithoutTitle = createMockProjectRequest({
+      ...mockRequest,
+      title: undefined,
+      projectName: 'my-website',
+    })
+    mockUseGetProjectRequestById.mockReturnValue({
+      data: { projectRequest: requestWithoutTitle },
+      loading: false,
+      error: undefined,
+    } as ReturnType<typeof useGetProjectRequestById>)
+
+    render(<ProjectRequestDetail id='1' />)
+
+    expect(screen.getByText('my-website')).toBeInTheDocument()
+  })
+})

--- a/src/components/molecules/project-request/ProjectRequestDetail.tsx
+++ b/src/components/molecules/project-request/ProjectRequestDetail.tsx
@@ -3,9 +3,10 @@
 import Link from 'next/link'
 
 import { useGetProjectRequestById } from '@/apiClients/projectRequestApiClient'
-import { RequirementsList } from '@/components/molecules'
 import { formatCardDate } from '@/utils'
 import { formatStatus, getStatusCardStyling } from '@/utils/Project'
+
+import { RequirementsList } from './RequirementsList'
 
 type ProjectRequestDetailProps = {
   id: string

--- a/src/components/molecules/project-request/index.ts
+++ b/src/components/molecules/project-request/index.ts
@@ -1,3 +1,4 @@
 export * from './ProjectRequestCard'
+export * from './ProjectRequestDetail'
 export * from './ProjectRequestForm'
 export * from './RequirementsList'

--- a/src/graphql/generated/graphql.ts
+++ b/src/graphql/generated/graphql.ts
@@ -655,6 +655,13 @@ export type GetProjectRequestsQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type GetProjectRequestsQuery = { readonly __typename?: 'Query', readonly projectRequests: ReadonlyArray<{ readonly __typename?: 'ProjectRequest', readonly id: string, readonly projectName: string, readonly title?: string | null, readonly description: string, readonly projectType: ProjectType, readonly budget?: number | null, readonly timeline?: string | null, readonly additionalInfo?: string | null, readonly status: ProjectStatus, readonly createdAt: string, readonly updatedAt: string, readonly requirements?: { readonly __typename?: 'ProjectRequirements', readonly hasDesign?: boolean | null, readonly needsHosting?: boolean | null, readonly hasDomain?: boolean | null, readonly needsMaintenance?: boolean | null, readonly needsContentCreation?: boolean | null, readonly needsSEO?: boolean | null } | null, readonly statusUpdates: ReadonlyArray<{ readonly __typename?: 'StatusUpdate', readonly id: string, readonly newStatus: ProjectStatus, readonly updateMessage: string, readonly createdAt: string }>, readonly user?: { readonly __typename?: 'User', readonly id: string, readonly firstName?: string | null, readonly lastName?: string | null, readonly email: string } | null }> };
 
+export type GetProjectRequestByIdQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type GetProjectRequestByIdQuery = { readonly __typename?: 'Query', readonly projectRequest?: { readonly __typename?: 'ProjectRequest', readonly id: string, readonly projectName: string, readonly title?: string | null, readonly description: string, readonly projectType: ProjectType, readonly budget?: number | null, readonly timeline?: string | null, readonly additionalInfo?: string | null, readonly status: ProjectStatus, readonly createdAt: string, readonly updatedAt: string, readonly requirements?: { readonly __typename?: 'ProjectRequirements', readonly hasDesign?: boolean | null, readonly needsHosting?: boolean | null, readonly hasDomain?: boolean | null, readonly needsMaintenance?: boolean | null, readonly needsContentCreation?: boolean | null, readonly needsSEO?: boolean | null } | null, readonly statusUpdates: ReadonlyArray<{ readonly __typename?: 'StatusUpdate', readonly id: string, readonly newStatus: ProjectStatus, readonly updateMessage: string, readonly createdAt: string }>, readonly user?: { readonly __typename?: 'User', readonly id: string, readonly firstName?: string | null, readonly lastName?: string | null, readonly email: string } | null } | null };
+
 export type CreateProjectRequestMutationVariables = Exact<{
   input: CreateProjectRequestInput;
 }>;
@@ -1408,6 +1415,40 @@ export function useGetProjectRequestsLazyQuery(baseOptions?: ApolloReactHooks.La
         }
 export type GetProjectRequestsQueryHookResult = ReturnType<typeof useGetProjectRequestsQuery>;
 export type GetProjectRequestsLazyQueryHookResult = ReturnType<typeof useGetProjectRequestsLazyQuery>;
+export const GetProjectRequestByIdDocument = gql`
+    query GetProjectRequestById($id: ID!) {
+  projectRequest(id: $id) {
+    ...ProjectRequestDisplay
+  }
+}
+    ${ProjectRequestDisplayFragmentDoc}`;
+
+/**
+ * __useGetProjectRequestByIdQuery__
+ *
+ * To run a query within a React component, call `useGetProjectRequestByIdQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetProjectRequestByIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetProjectRequestByIdQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetProjectRequestByIdQuery(baseOptions: ApolloReactHooks.QueryHookOptions<GetProjectRequestByIdQuery, GetProjectRequestByIdQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<GetProjectRequestByIdQuery, GetProjectRequestByIdQueryVariables>(GetProjectRequestByIdDocument, options);
+      }
+export function useGetProjectRequestByIdLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetProjectRequestByIdQuery, GetProjectRequestByIdQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<GetProjectRequestByIdQuery, GetProjectRequestByIdQueryVariables>(GetProjectRequestByIdDocument, options);
+        }
+export type GetProjectRequestByIdQueryHookResult = ReturnType<typeof useGetProjectRequestByIdQuery>;
+export type GetProjectRequestByIdLazyQueryHookResult = ReturnType<typeof useGetProjectRequestByIdLazyQuery>;
 export const CreateProjectRequestDocument = gql`
     mutation CreateProjectRequest($input: CreateProjectRequestInput!) {
   createProjectRequest(input: $input) {


### PR DESCRIPTION
## Summary
- "VIEW REQUEST" on `ProjectStatusCard` was routing to `/projects/[slug]`, which only queries the `projects` table — causing a 404 for project requests
- Added `GET_PROJECT_REQUEST_BY_ID` query + `useGetProjectRequestById` hook and ran codegen
- Created `/dashboard/project-requests/[id]` route with a read-only detail view (title, status, description, requirements, budget/timeline, additional info, and status update history)

## Test plan
- [ ] Submit a project request as a client user
- [ ] Go to Dashboard — click "VIEW REQUEST" on the request card
- [ ] Confirm it routes to `/dashboard/project-requests/[id]` and displays request details
- [ ] Confirm "VIEW DETAILS" on a project card still routes correctly to `/projects/[slug]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now view comprehensive details for individual project requests, including budget, timeline, requirements, and status update history.
  * Project request cards now navigate to the dedicated request details page instead of the project view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->