### PR TITLE
fix(projects): public project access and left-column link layout

### DIFF
--- a/src/components/atoms/controls/Button.tsx
+++ b/src/components/atoms/controls/Button.tsx
@@ -14,7 +14,7 @@ type ButtonProps = {
 }
 
 const baseStyles =
-  'inline-block cursor-pointer rounded border font-mono font-bold transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-50'
+  'inline-block cursor-pointer rounded border font-mono font-bold text-center transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-50'
 
 const buttonStyle =
   'border-green-400 bg-green-400/10 text-green-400 hover:bg-green-400 hover:text-black'

--- a/src/components/templates/CleanPageTemplate.tsx
+++ b/src/components/templates/CleanPageTemplate.tsx
@@ -5,5 +5,5 @@ type CleanPageTemplateProps = {
 }
 
 export const CleanPageTemplate = ({ children }: CleanPageTemplateProps) => {
-  return <div className='min-h-screen bg-black pt-32'>{children}</div>
+  return <div className='min-h-screen bg-black pt-32 pb-8'>{children}</div>
 }

--- a/src/components/templates/ProjectDetailsTemplate.tsx
+++ b/src/components/templates/ProjectDetailsTemplate.tsx
@@ -287,6 +287,39 @@ export const ProjectDetailsTemplate = ({
                   {formatStatus(optimisticStatus)}
                 </span>
               </div>
+
+              {/* Repo / Staging / Live links */}
+              {(repoUrl || canProvisionRepo || stagingUrl || project.liveUrl) && (
+                <div className='flex w-[300px] flex-col gap-3'>
+                  {repoUrl ? (
+                    <Button href={repoUrl} external size='md'>
+                      VIEW REPOSITORY
+                    </Button>
+                  ) : canProvisionRepo ? (
+                    <Button
+                      onClick={handleProvisionRepo}
+                      disabled={provisioning}
+                      size='md'
+                    >
+                      {provisioning ? 'PROVISIONING...' : 'PROVISION REPO'}
+                    </Button>
+                  ) : null}
+                  {stagingUrl && (
+                    <Button href={stagingUrl} external size='md'>
+                      VIEW STAGING
+                    </Button>
+                  )}
+                  {project.liveUrl && (
+                    <Button
+                      href={project.liveUrl}
+                      external={project.liveUrl.startsWith('http')}
+                      size='md'
+                    >
+                      ACCESS PROJECT
+                    </Button>
+                  )}
+                </div>
+              )}
             </div>
           </ScrollFade>
 
@@ -395,46 +428,6 @@ export const ProjectDetailsTemplate = ({
           </ScrollFade>
         </div>
 
-        {/* Repository Section */}
-        {(repoUrl || canProvisionRepo) && (
-          <ScrollFade>
-            <div className='mt-12 flex justify-center gap-4'>
-              {repoUrl ? (
-                <Button href={repoUrl} external size='md'>
-                  VIEW REPOSITORY
-                </Button>
-              ) : (
-                <Button
-                  onClick={handleProvisionRepo}
-                  disabled={provisioning}
-                  size='md'
-                >
-                  {provisioning ? 'PROVISIONING...' : 'PROVISION REPO'}
-                </Button>
-              )}
-              {stagingUrl && (
-                <Button href={stagingUrl} external size='md'>
-                  VIEW STAGING
-                </Button>
-              )}
-            </div>
-          </ScrollFade>
-        )}
-
-        {/* Access Project Button */}
-        {project.liveUrl && (
-          <ScrollFade>
-            <div className='mt-8 text-center'>
-              <Button
-                href={project.liveUrl}
-                external={project.liveUrl.startsWith('http')}
-                size='md'
-              >
-                ACCESS PROJECT
-              </Button>
-            </div>
-          </ScrollFade>
-        )}
       </div>
     </CleanPageTemplate>
   )

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -4,6 +4,7 @@ import { GraphQLError } from 'graphql'
 import type { ProjectFilter } from '@/graphql/schema'
 import type { ProjectRecord } from '@/models'
 
+import { SUPPORT_EMAIL } from '@/constants'
 import { ProjectFeature, ProjectStatus, UserRole } from '@/graphql/schema'
 import { db } from '@/libs/DB'
 import { Env } from '@/libs/Env'
@@ -122,9 +123,7 @@ export class ProjectService {
     currentUserId?: string,
     currentUserRole?: string
   ): Promise<ProjectRecord> {
-    // Get all projects and find the one that matches the slug
     const allProjects = await db.query.projects.findMany()
-
     const project = findProjectBySlug<ProjectRecord>(slug, allProjects)
 
     if (!project) {
@@ -133,48 +132,35 @@ export class ProjectService {
       })
     }
 
-    // If no user is provided (public access), only allow access to c0d3ster's projects
-    if (!currentUserId || !currentUserRole) {
-      // Get c0d3ster's user ID
-      const c0d3sterUser = await db.query.users.findFirst({
-        where: eq(schemas.users.email, 'support@c0d3ster.com'),
-      })
-
-      if (!c0d3sterUser) {
-        throw new GraphQLError('Access denied', {
-          extensions: { code: 'FORBIDDEN' },
-        })
-      }
-
-      // Only allow public access if c0d3ster is the developer or the client
-      if (
-        project.developerId !== c0d3sterUser.id &&
-        project.clientId !== c0d3sterUser.id
-      ) {
-        throw new GraphQLError('Access denied', {
-          extensions: { code: 'FORBIDDEN' },
-        })
-      }
-
-      return project
-    }
-
     // Admins can access all projects
     if (isAdminRole(currentUserRole)) {
       return project
     }
 
-    // Allow access if user is the client or developer of the project (regardless of role)
-    const hasProjectAccess =
-      project.clientId === currentUserId ||
-      project.developerId === currentUserId
-    if (!hasProjectAccess) {
-      throw new GraphQLError('Access denied', {
-        extensions: { code: 'FORBIDDEN' },
-      })
+    // Project owner (client or developer) can always access
+    if (
+      currentUserId &&
+      (project.clientId === currentUserId || project.developerId === currentUserId)
+    ) {
+      return project
     }
 
-    return project
+    // Anyone (authenticated or not) can view c0d3ster's projects
+    const c0d3sterUser = await db.query.users.findFirst({
+      where: eq(schemas.users.email, SUPPORT_EMAIL),
+    })
+
+    if (
+      c0d3sterUser &&
+      (project.developerId === c0d3sterUser.id ||
+        project.clientId === c0d3sterUser.id)
+    ) {
+      return project
+    }
+
+    throw new GraphQLError('Access denied', {
+      extensions: { code: 'FORBIDDEN' },
+    })
   }
 
   async getMyProjects(


### PR DESCRIPTION
## Summary
- **Bug fix:** Signed-in users who aren't the project owner were getting "Access denied" on c0d3ster's public project pages. Unauthenticated users worked fine because they had a c0d3ster ownership check, but authenticated non-owners were denied immediately without it. Unified `getProjectBySlug` access into a single flow: admin → project owner → c0d3ster portfolio → deny.
- **Layout:** Moved VIEW REPOSITORY / PROVISION REPO / VIEW STAGING / ACCESS PROJECT buttons from full-width centered sections below the two-column grid into the left column below the status badge.

## Test plan
- [ ] Visit a project page (`/projects/[slug]`) while not signed in — should load
- [ ] Visit same page signed in as c0d3ster — should load
- [ ] Visit same page signed in as a different user — should now load (was previously "Access denied")
- [ ] Visit a non-c0d3ster project page as an unrelated user — should still get Access denied
- [ ] On project detail page, confirm repo/staging/live buttons appear in left column below status badge, not below the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)