### PR TITLE
fix(dashboard): refetch GetMyDashboard after admin approve/status update

### DIFF
--- a/src/components/molecules/project-card/ProjectCard.tsx
+++ b/src/components/molecules/project-card/ProjectCard.tsx
@@ -40,12 +40,12 @@ export const ProjectCard = ({ project }: ProjectCardProps) => {
         )}
 
         {/* Project Title */}
-        <h3 className='mb-2 pr-12 font-mono text-lg font-bold text-green-400'>
+        <h3 className='mb-2 pr-14 font-mono text-lg font-bold text-green-400'>
           {project.title || project.projectName}
         </h3>
 
         {/* Project Description */}
-        <p className='mb-4 pr-12 font-mono text-sm text-green-300 opacity-80'>
+        <p className='mb-4 pr-14 font-mono text-sm text-green-300 opacity-80'>
           {project.overview || project.description}
         </p>
 

--- a/src/components/organisms/dashboard/DashboardContent.tsx
+++ b/src/components/organisms/dashboard/DashboardContent.tsx
@@ -180,7 +180,7 @@ export const DashboardContent = () => {
               </div>
             </div>
           </div>
-          <AdminDashboardSection />
+          <AdminDashboardSection onDataRefreshAction={refetchDashboard} />
         </div>
       )}
 

--- a/src/components/organisms/dashboard/sections/AdminDashboardSection.tsx
+++ b/src/components/organisms/dashboard/sections/AdminDashboardSection.tsx
@@ -10,7 +10,11 @@ import {
 import { ProjectRequestCard } from '@/components/molecules'
 import { Toast } from '@/libs/Toast'
 
-export const AdminDashboardSection = () => {
+type AdminDashboardSectionProps = {
+  onDataRefreshAction?: () => void
+}
+
+export const AdminDashboardSection = ({ onDataRefreshAction }: AdminDashboardSectionProps) => {
   const {
     data: projectRequestsData,
     loading: adminLoading,
@@ -31,6 +35,7 @@ export const AdminDashboardSection = () => {
       await updateStatusMutation({ variables: { id: requestId, status } })
       Toast.success(`Project request status updated to ${status}`)
       await adminRefetch()
+      onDataRefreshAction?.()
     } catch (error) {
       Toast.error('Failed to update request status')
       console.error('Update request status error:', error)
@@ -45,6 +50,7 @@ export const AdminDashboardSection = () => {
       await approveMutation({ variables: { id: requestId } })
       Toast.success('Project request approved and project created!')
       await adminRefetch()
+      onDataRefreshAction?.()
     } catch (error) {
       Toast.error('Failed to approve request')
       console.error('Approve request error:', error)


### PR DESCRIPTION
## Summary

- After approving or updating a project request, `AdminDashboardSection` now triggers `onDataRefreshAction` to refetch `GetMyDashboard`
- Previously only `GetProjectRequests` was refetched, leaving the dashboard stale
- Pending requests stayed visible in "YOUR REQUESTS" and new projects never appeared in "AVAILABLE PROJECTS" for assignment

## Test plan

- [ ] Approve a pending project request as admin
- [ ] Confirm the request disappears from "YOUR REQUESTS" immediately after approval
- [ ] Confirm the new project appears in "AVAILABLE PROJECTS" without a page refresh
- [ ] Assign yourself to the project and confirm it moves to "ASSIGNED PROJECTS"
- [ ] Verify status updates (e.g. Start Review, Reject) also refresh the dashboard correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin dashboard data now refreshes automatically after admin actions complete, such as status updates and request approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->