### PR TITLE
fix(dashboard): admin requests dashboard improvements

### DIFF
--- a/src/components/molecules/project-request/ProjectRequestCard.tsx
+++ b/src/components/molecules/project-request/ProjectRequestCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { useState } from 'react'
 
 import type { ProjectRequest } from '@/graphql/generated/graphql'
@@ -78,7 +79,12 @@ export const ProjectRequestCard = ({
     'Unknown User'
 
   return (
-    <div className='rounded-lg border border-green-400/20 bg-black/60 p-6 backdrop-blur-sm'>
+    <div className='relative rounded-lg border border-green-400/20 bg-black/60 p-6 backdrop-blur-sm transition-colors duration-200 hover:border-green-400/40'>
+      <Link
+        href={`/dashboard/project-requests/${request.id}`}
+        className='absolute inset-0 rounded-lg'
+        aria-label={`View details for ${request.title}`}
+      />
       {/* Header */}
       <div className='mb-4'>
         <div className='mb-2 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between'>
@@ -150,7 +156,7 @@ export const ProjectRequestCard = ({
       )}
 
       {/* Action Buttons */}
-      <div className='flex flex-wrap gap-2'>
+      <div className='relative z-10 flex flex-wrap gap-2'>
         {request.status === ProjectStatus.Requested && (
           <button
             type='button'
@@ -197,7 +203,7 @@ export const ProjectRequestCard = ({
 
       {/* Approval Form Modal */}
       {showApprovalForm && (
-        <div className='mt-6 rounded border border-green-400/30 bg-green-400/5 p-4'>
+        <div className='relative z-10 mt-6 rounded border border-green-400/30 bg-green-400/5 p-4'>
           <h4 className='mb-4 font-mono text-sm font-bold text-green-400'>
             Project Approval Details
           </h4>

--- a/src/components/organisms/dashboard/sections/AdminDashboardSection.test.tsx
+++ b/src/components/organisms/dashboard/sections/AdminDashboardSection.test.tsx
@@ -105,10 +105,11 @@ describe('AdminDashboardSection', () => {
 
     render(<AdminDashboardSection />)
 
+    expect(screen.getByText('ACTIONABLE (2)')).toBeInTheDocument()
     expect(screen.getByText('ALL (3)')).toBeInTheDocument()
-    expect(screen.getByText('REQUESTED (0)')).toBeInTheDocument()
-    expect(screen.getByText('IN REVIEW (0)')).toBeInTheDocument()
-    expect(screen.getByText('APPROVED (0)')).toBeInTheDocument()
+    expect(screen.getByText('REQUESTED (1)')).toBeInTheDocument()
+    expect(screen.getByText('IN REVIEW (1)')).toBeInTheDocument()
+    expect(screen.getByText('APPROVED (1)')).toBeInTheDocument()
     expect(screen.getByText('CANCELLED (0)')).toBeInTheDocument()
   })
 
@@ -122,7 +123,7 @@ describe('AdminDashboardSection', () => {
 
     render(<AdminDashboardSection />)
 
-    // Initially shows all requests
+    // Initially shows actionable requests only (Requested + InReview, not Approved)
     expect(
       screen.getByTestId('project-request-card-request1')
     ).toBeInTheDocument()
@@ -130,17 +131,15 @@ describe('AdminDashboardSection', () => {
       screen.getByTestId('project-request-card-request2')
     ).toBeInTheDocument()
     expect(
-      screen.getByTestId('project-request-card-request3')
-    ).toBeInTheDocument()
-
-    // Click on "REQUESTED" filter
-    fireEvent.click(screen.getByText('REQUESTED (0)'))
-
-    // Should show empty state since there are no requested items
-    expect(screen.getByText('No requested requests')).toBeInTheDocument()
-    expect(
-      screen.queryByTestId('project-request-card-request1')
+      screen.queryByTestId('project-request-card-request3')
     ).not.toBeInTheDocument()
+
+    // Click on "REQUESTED" filter — shows only the 1 requested item
+    fireEvent.click(screen.getByText('REQUESTED (1)'))
+
+    expect(
+      screen.getByTestId('project-request-card-request1')
+    ).toBeInTheDocument()
     expect(
       screen.queryByTestId('project-request-card-request2')
     ).not.toBeInTheDocument()
@@ -353,12 +352,11 @@ describe('AdminDashboardSection', () => {
 
     render(<AdminDashboardSection />)
 
-    const requestedButton = screen.getByText('REQUESTED (0)')
+    const actionableButton = screen.getByText('ACTIONABLE (2)')
+    const requestedButton = screen.getByText('REQUESTED (1)')
 
-    // Initially "ALL" should be selected
-    const allButton = screen.getByText('ALL (3)')
-
-    expect(allButton).toHaveClass(
+    // Initially "ACTIONABLE" should be selected
+    expect(actionableButton).toHaveClass(
       'border-green-400',
       'bg-green-400',
       'text-black'
@@ -373,6 +371,6 @@ describe('AdminDashboardSection', () => {
       'bg-green-400',
       'text-black'
     )
-    expect(allButton).not.toHaveClass('bg-green-400', 'text-black')
+    expect(actionableButton).not.toHaveClass('bg-green-400', 'text-black')
   })
 })

--- a/src/components/organisms/dashboard/sections/AdminDashboardSection.tsx
+++ b/src/components/organisms/dashboard/sections/AdminDashboardSection.tsx
@@ -8,6 +8,7 @@ import {
   useUpdateProjectRequestStatus,
 } from '@/apiClients'
 import { ProjectRequestCard } from '@/components/molecules'
+import { ProjectStatus } from '@/graphql/generated/graphql'
 import { Toast } from '@/libs/Toast'
 
 type AdminDashboardSectionProps = {
@@ -24,7 +25,7 @@ export const AdminDashboardSection = ({ onDataRefreshAction }: AdminDashboardSec
   const [approveMutation] = useApproveProjectRequest()
   const [updateStatusMutation] = useUpdateProjectRequestStatus()
 
-  const [statusFilter, setStatusFilter] = useState<string>('all')
+  const [statusFilter, setStatusFilter] = useState<ProjectStatus | 'all'>('all')
 
   // Get the project requests directly from GraphQL
   const adminRequests = projectRequestsData?.projectRequests || []
@@ -84,23 +85,28 @@ export const AdminDashboardSection = ({ onDataRefreshAction }: AdminDashboardSec
     <>
       {/* Filter Bar */}
       <div className='mb-6 flex flex-wrap gap-2'>
-        {['all', 'requested', 'in_review', 'approved', 'cancelled'].map(
-          (status) => (
-            <button
-              key={status}
-              type='button'
-              onClick={() => setStatusFilter(status)}
-              className={`rounded border px-3 py-1 font-mono text-xs font-bold transition-all duration-300 ${
-                statusFilter === status
-                  ? 'border-green-400 bg-green-400 text-black'
-                  : 'border-green-400/30 bg-green-400/10 text-green-400 hover:bg-green-400 hover:text-black'
-              }`}
-            >
-              {status.toUpperCase().replace('_', ' ')} (
-              {statusCounts[status as keyof typeof statusCounts] || 0})
-            </button>
-          )
-        )}
+        {(
+          [
+            ['all', 'ALL'],
+            [ProjectStatus.Requested, 'REQUESTED'],
+            [ProjectStatus.InReview, 'IN REVIEW'],
+            [ProjectStatus.Approved, 'APPROVED'],
+            [ProjectStatus.Cancelled, 'CANCELLED'],
+          ] as const
+        ).map(([value, label]) => (
+          <button
+            key={value}
+            type='button'
+            onClick={() => setStatusFilter(value)}
+            className={`rounded border px-3 py-1 font-mono text-xs font-bold transition-all duration-300 ${
+              statusFilter === value
+                ? 'border-green-400 bg-green-400 text-black'
+                : 'border-green-400/30 bg-green-400/10 text-green-400 hover:bg-green-400 hover:text-black'
+            }`}
+          >
+            {label} ({statusCounts[value as keyof typeof statusCounts] || 0})
+          </button>
+        ))}
       </div>
 
       {/* Admin Section - Project Requests */}
@@ -135,7 +141,7 @@ export const AdminDashboardSection = ({ onDataRefreshAction }: AdminDashboardSec
           <p className='mb-2 font-mono text-sm text-green-300'>
             {statusFilter === 'all'
               ? 'No project requests found'
-              : `No ${(statusFilter || 'unknown').replace('_', ' ')} requests`}
+              : `No ${statusFilter.replace(/([A-Z])/g, ' $1').trim().toLowerCase()} requests`}
           </p>
           <p className='font-mono text-xs text-green-300/60'>
             Requests will appear here when clients submit them

--- a/src/components/organisms/dashboard/sections/AdminDashboardSection.tsx
+++ b/src/components/organisms/dashboard/sections/AdminDashboardSection.tsx
@@ -25,7 +25,7 @@ export const AdminDashboardSection = ({ onDataRefreshAction }: AdminDashboardSec
   const [approveMutation] = useApproveProjectRequest()
   const [updateStatusMutation] = useUpdateProjectRequestStatus()
 
-  const [statusFilter, setStatusFilter] = useState<ProjectStatus | 'all'>('all')
+  const [statusFilter, setStatusFilter] = useState<ProjectStatus | 'all' | 'actionable'>('actionable')
 
   // Get the project requests directly from GraphQL
   const adminRequests = projectRequestsData?.projectRequests || []
@@ -61,22 +61,22 @@ export const AdminDashboardSection = ({ onDataRefreshAction }: AdminDashboardSec
   // Admin request filtering
   const filteredRequests = adminRequests.filter((request: any) => {
     if (statusFilter === 'all') return true
+    if (statusFilter === 'actionable')
+      return request.status === ProjectStatus.Requested || request.status === ProjectStatus.InReview
     return request.status === statusFilter
   })
 
   const getStatusCounts = () => {
-    const counts = {
+    const requested = adminRequests.filter((r: any) => r.status === ProjectStatus.Requested).length
+    const inReview = adminRequests.filter((r: any) => r.status === ProjectStatus.InReview).length
+    return {
+      actionable: requested + inReview,
       all: adminRequests.length,
-      requested: adminRequests.filter((r: any) => r.status === 'requested')
-        .length,
-      in_review: adminRequests.filter((r: any) => r.status === 'in_review')
-        .length,
-      approved: adminRequests.filter((r: any) => r.status === 'approved')
-        .length,
-      cancelled: adminRequests.filter((r: any) => r.status === 'cancelled')
-        .length,
+      [ProjectStatus.Requested]: requested,
+      [ProjectStatus.InReview]: inReview,
+      [ProjectStatus.Approved]: adminRequests.filter((r: any) => r.status === ProjectStatus.Approved).length,
+      [ProjectStatus.Cancelled]: adminRequests.filter((r: any) => r.status === ProjectStatus.Cancelled).length,
     }
-    return counts
   }
 
   const statusCounts = getStatusCounts()
@@ -87,6 +87,7 @@ export const AdminDashboardSection = ({ onDataRefreshAction }: AdminDashboardSec
       <div className='mb-6 flex flex-wrap gap-2'>
         {(
           [
+            ['actionable', 'ACTIONABLE'],
             ['all', 'ALL'],
             [ProjectStatus.Requested, 'REQUESTED'],
             [ProjectStatus.InReview, 'IN REVIEW'],
@@ -139,7 +140,7 @@ export const AdminDashboardSection = ({ onDataRefreshAction }: AdminDashboardSec
         <div className='flex flex-col items-center justify-center py-12 text-center'>
           <div className='mb-4 text-4xl'>📋</div>
           <p className='mb-2 font-mono text-sm text-green-300'>
-            {statusFilter === 'all'
+            {statusFilter === 'all' || statusFilter === 'actionable'
               ? 'No project requests found'
               : `No ${statusFilter.replace(/([A-Z])/g, ' $1').trim().toLowerCase()} requests`}
           </p>


### PR DESCRIPTION
## Summary

- **Fix broken status filter** — filter buttons were using lowercase snake_case strings (`'requested'`, `'in_review'`) but GraphQL returns PascalCase enum values (`'Requested'`, `'InReview'`), causing all filters to show empty results
- **Default to actionable requests** — add ACTIONABLE tab (Requested + InReview) and make it the default; approved/cancelled are now hidden unless explicitly filtered
- **Clickable cards** — each request card now navigates to `/dashboard/project-requests/[id]` via a stretched `<Link>`; action buttons and approval form sit above it with `z-10` so their interactions are unaffected

## Test plan

- [ ] Status filter buttons correctly show/hide requests by status
- [ ] Dashboard loads with ACTIONABLE tab active, showing only requested + in-review items
- [ ] Clicking the card body navigates to the detail page
- [ ] Start Review, Reject, and Approve & Create Project buttons still work without triggering navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced project request cards to be fully clickable while keeping buttons and approval flows usable.
  * Improved admin dashboard status filtering by using a typed project status set, adding an “actionable” view, and updating counts/empty-state messaging accordingly.
* **Tests**
  * Updated admin dashboard tests to match the new default “actionable” filter behavior and revised filter button counts/styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->