### PR TITLE
fix(ui): header dropdown hover trigger and featured star position

### DIFF
--- a/src/components/organisms/navigation/SiteHeader.tsx
+++ b/src/components/organisms/navigation/SiteHeader.tsx
@@ -195,8 +195,8 @@ export const SiteHeader = ({
           </div>
 
           {/* Dropdown menu */}
-          <div className='pointer-events-none absolute top-full right-0 z-50 mt-2 min-w-32 rounded-lg border border-green-400/20 bg-black/90 opacity-0 shadow-lg backdrop-blur-sm transition-opacity duration-200 group-hover:pointer-events-auto group-hover:opacity-100'>
-            <div className='py-2'>
+          <div className='pointer-events-none absolute top-full right-0 z-50 min-w-32 pt-2 opacity-0 transition-opacity duration-200 group-hover:pointer-events-auto group-hover:opacity-100'>
+            <div className='rounded-lg border border-green-400/20 bg-black/90 py-2 shadow-lg backdrop-blur-sm'>
               <SignOutButton>
                 <button
                   type='button'
@@ -231,8 +231,8 @@ export const SiteHeader = ({
           </div>
 
           {/* Dropdown menu */}
-          <div className='pointer-events-none absolute top-full right-0 z-50 mt-2 min-w-32 rounded-lg border border-green-400/20 bg-black/90 opacity-0 shadow-lg backdrop-blur-sm transition-opacity duration-200 group-hover:pointer-events-auto group-hover:opacity-100'>
-            <div className='py-2'>
+          <div className='pointer-events-none absolute top-full right-0 z-50 min-w-32 pt-2 opacity-0 transition-opacity duration-200 group-hover:pointer-events-auto group-hover:opacity-100'>
+            <div className='rounded-lg border border-green-400/20 bg-black/90 py-2 shadow-lg backdrop-blur-sm'>
               {isLoaded && user ? (
                 <>
                   <Link

--- a/src/components/organisms/navigation/SiteHeader.tsx
+++ b/src/components/organisms/navigation/SiteHeader.tsx
@@ -195,7 +195,7 @@ export const SiteHeader = ({
           </div>
 
           {/* Dropdown menu */}
-          <div className='absolute top-full right-0 z-50 mt-2 min-w-32 rounded-lg border border-green-400/20 bg-black/90 opacity-0 shadow-lg backdrop-blur-sm transition-opacity duration-200 group-hover:opacity-100'>
+          <div className='pointer-events-none absolute top-full right-0 z-50 mt-2 min-w-32 rounded-lg border border-green-400/20 bg-black/90 opacity-0 shadow-lg backdrop-blur-sm transition-opacity duration-200 group-hover:pointer-events-auto group-hover:opacity-100'>
             <div className='py-2'>
               <SignOutButton>
                 <button
@@ -231,7 +231,7 @@ export const SiteHeader = ({
           </div>
 
           {/* Dropdown menu */}
-          <div className='absolute top-full right-0 z-50 mt-2 min-w-32 rounded-lg border border-green-400/20 bg-black/90 opacity-0 shadow-lg backdrop-blur-sm transition-opacity duration-200 group-hover:opacity-100'>
+          <div className='pointer-events-none absolute top-full right-0 z-50 mt-2 min-w-32 rounded-lg border border-green-400/20 bg-black/90 opacity-0 shadow-lg backdrop-blur-sm transition-opacity duration-200 group-hover:pointer-events-auto group-hover:opacity-100'>
             <div className='py-2'>
               {isLoaded && user ? (
                 <>

--- a/src/components/templates/ProjectDetailsTemplate.tsx
+++ b/src/components/templates/ProjectDetailsTemplate.tsx
@@ -180,6 +180,25 @@ export const ProjectDetailsTemplate = ({
   return (
     <CleanPageTemplate>
       <BackButton useBack text='BACK' />
+      {canManageFeatured && (
+        <div className='fixed top-24 right-0 left-0 z-40'>
+          <div className='container mx-auto px-4'>
+            <div className='flex justify-end'>
+              <button
+                type='button'
+                onClick={handleToggleFeatured}
+                disabled={updatingFeatured}
+                className='cursor-pointer text-green-600 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-40'
+                title={featured ? 'Remove from featured' : 'Add to featured'}
+                aria-label={featured ? 'Remove from featured' : 'Add to featured'}
+                aria-pressed={featured}
+              >
+                {featured ? <FaStar className='h-5 w-5' /> : <FaRegStar className='h-5 w-5' />}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       <div className='container mx-auto px-4 pb-8 md:pb-12'>
         {/* Project Header */}
         <ScrollFade>
@@ -409,25 +428,6 @@ export const ProjectDetailsTemplate = ({
           {/* Project Details */}
           <ScrollFade>
             <div className='space-y-8'>
-              {/* Featured toggle — admin only (controls public portfolio) */}
-              {canManageFeatured && (
-                <div className='flex justify-end'>
-                  <button
-                    type='button'
-                    onClick={handleToggleFeatured}
-                    disabled={updatingFeatured}
-                    className='cursor-pointer text-green-600 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-40'
-                    title={featured ? 'Remove from featured' : 'Add to featured'}
-                    aria-label={featured ? 'Remove from featured' : 'Add to featured'}
-                    aria-pressed={featured}
-                  >
-                    {featured
-                      ? <FaStar className='h-5 w-5' />
-                      : <FaRegStar className='h-5 w-5' />}
-                  </button>
-                </div>
-              )}
-
               {/* Post update — primary action for admins / assigned dev */}
               {canPostUpdate && (
                 <PostUpdatePanel


### PR DESCRIPTION
## Summary

- **SiteHeader dropdown hover fix** — the dropdown was appearing on hover anywhere in the container because `opacity-0` elements still receive pointer events. Added `pointer-events-none` to the hidden dropdown and `group-hover:pointer-events-auto` to re-enable on reveal. Applied to both the dashboard and public site dropdowns.
- **Featured star repositioned** — moved the star out of the right column grid and into a `fixed top-24` layer that mirrors the `BackButton` layout, placing it at the far top-right of the container.

## Test plan

- [ ] Hovering near the top-right corner of the header does NOT trigger the dropdown — only hovering over GUEST or ONLINE does
- [ ] Dropdown stays open when moving the mouse from the text into the menu
- [ ] Featured star appears at top-right of project details page (admin only)
- [ ] Star toggle still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)