### PR TITLE
fix(back-button): raise z-index above featured star overlay

### DIFF
--- a/src/components/atoms/controls/BackButton.tsx
+++ b/src/components/atoms/controls/BackButton.tsx
@@ -25,7 +25,7 @@ export const BackButton = ({
   }
 
   return (
-    <div className='fixed top-24 right-0 left-0 z-40'>
+    <div className='fixed top-24 right-0 left-0 z-50'>
       <div className='container mx-auto px-4'>
         <Link
           href={useBack ? '#' : href || '/'}


### PR DESCRIPTION
## Summary
- Bumps `BackButton` z-index from `z-40` to `z-50` so it renders above the featured star fixed overlay, restoring click access on the project details page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the back button’s visibility by ensuring it appears above overlapping interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->