### PR TITLE
fix(files): drop redundant env prefix from R2 object keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,21 @@ Vitest runs two projects (vitest.config.mts):
 
 E2E specs (`*.spec.ts`/`*.e2e.ts`) are excluded from `tsc` and from the vitest globs, and get relaxed lint rules (quotes) via `eslint.config.mjs`.
 
+## Database migrations (Drizzle)
+
+Schema changes (add/remove/alter a column, table, or enum):
+1. Edit the schema in `src/models/**` first.
+2. Run `npm run db:generate`. drizzle-kit diffs your change against `migrations/meta/*_snapshot.json` and writes a new `migrations/00XX_<random-words>.sql`, a matching snapshot, and a journal entry in `migrations/meta/_journal.json`.
+3. Review the generated SQL.
+4. Rename the file from drizzle-kit's random-word name to a short descriptive slug, keeping the numeric prefix (e.g. `0018_hazy_falcon.sql` -> `0018_add_invoice_status.sql`).
+5. Update the matching entry's `"tag"` in `migrations/meta/_journal.json` to the new filename minus `.sql`. This is the step that gets skipped and breaks `db:migrate` (it looks up files by tag, not by number).
+6. Run `npm run db:migrate`.
+
+Data-only migrations (backfilling or renaming stored values, no column/type change):
+- `db:generate` diffs `src/models/**` against the last snapshot. With no schema change there's nothing to diff, so it silently generates nothing. Don't try to force one through drizzle-kit for a pure data fix.
+- If the fix is pure SQL, hand-write a numbered `.sql` file in `migrations/` and add its own `_journal.json` entry (reuse the prior snapshot unchanged, since the schema didn't move).
+- If the fix needs to touch anything outside the DB in lockstep with a column update (e.g. renaming R2 object keys while updating the row that points at them), it can't be a migration file at all. Write a standalone script instead (see `scripts/`), reading credentials from env, not through Drizzle's migration system.
+
 ## Conventions enforced by tooling
 
 - Commit messages must be Conventional Commits (commitlint + lefthook `commit-msg` hook); `semantic-release` on `main` drives GitHub releases from that history. Use `npm run commit` for an interactive prompt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ Data-only migrations (backfilling or renaming stored values, no column/type chan
 - `db:generate` diffs `src/models/**` against the last snapshot. With no schema change there's nothing to diff, so it silently generates nothing. Don't try to force one through drizzle-kit for a pure data fix.
 - If the fix is pure SQL, hand-write a numbered `.sql` file in `migrations/` and add its own `_journal.json` entry (reuse the prior snapshot unchanged, since the schema didn't move).
 - If the fix needs to touch anything outside the DB in lockstep with a column update (e.g. renaming R2 object keys while updating the row that points at them), it can't be a migration file at all. Write a standalone script instead (see `scripts/`), reading credentials from env, not through Drizzle's migration system.
+- Cross-system scripts like that must be idempotent, resumable, and support a dry run: for each row, copy/create the new external resource and verify it before touching anything, update the DB row only after the new resource is confirmed to exist, and only then delete the old external resource. That ordering means a crash or partial failure always leaves the DB pointing at something real, never at something already deleted. Re-running the script should just skip whatever's already migrated, not error or double-apply.
 
 ## Conventions enforced by tooling
 

--- a/src/apiClients/fileApiClient.ts
+++ b/src/apiClients/fileApiClient.ts
@@ -14,6 +14,7 @@ import type {
 } from '@/graphql/generated/graphql'
 
 import { apolloClient } from '@/libs/ApolloClient'
+import { isPublicUrl } from '@/utils'
 
 export const REQUEST_PROJECT_LOGO_UPLOAD = gql`
   mutation RequestProjectLogoUpload(
@@ -116,6 +117,21 @@ export const useGetFile = (key: string) => {
     variables: { key },
     skip: !key,
   })
+}
+
+/**
+ * Resolves a project/file field that may be either a browser-loadable URL
+ * (public asset, or a presigned URL) or a bare R2 object key into a usable URL.
+ */
+export const useResolvedFileUrl = (
+  key?: string | null
+): { url: string | undefined; loading: boolean } => {
+  const shouldFetch = !!key && !isPublicUrl(key)
+  const { data, loading } = useGetFile(shouldFetch ? key : '')
+
+  if (!key) return { url: undefined, loading: false }
+  if (isPublicUrl(key)) return { url: key, loading: false }
+  return { url: data?.file?.downloadUrl ?? undefined, loading }
 }
 
 /**

--- a/src/components/molecules/project-card/ProjectCard.test.tsx
+++ b/src/components/molecules/project-card/ProjectCard.test.tsx
@@ -12,6 +12,14 @@ vi.mock('@/utils', () => ({
   getStatusStyling: (_status: string) => 'text-green-400',
 }))
 
+// Mock apiClients
+vi.mock('@/apiClients', () => ({
+  useResolvedFileUrl: (key?: string | null) => ({
+    url: key ?? undefined,
+    loading: false,
+  }),
+}))
+
 const mockProject = createMockProject({
   featured: true,
 })

--- a/src/components/molecules/project-card/ProjectCard.tsx
+++ b/src/components/molecules/project-card/ProjectCard.tsx
@@ -6,6 +6,7 @@ import { FaStar } from 'react-icons/fa'
 
 import type { ProjectDisplayFragment } from '@/graphql/generated/graphql'
 
+import { useResolvedFileUrl } from '@/apiClients'
 import { formatStatus, generateSlug, getStatusStyling } from '@/utils'
 
 type ProjectCardProps = {
@@ -13,6 +14,8 @@ type ProjectCardProps = {
 }
 
 export const ProjectCard = ({ project }: ProjectCardProps) => {
+  const { url: logoUrl } = useResolvedFileUrl(project.logo)
+
   // Generate internal project detail URL
   const getProjectUrl = (projectName?: string) => {
     if (!projectName) return '/projects'
@@ -27,10 +30,10 @@ export const ProjectCard = ({ project }: ProjectCardProps) => {
     <Link href={projectUrl} className='block'>
       <div className='group relative cursor-pointer rounded-lg border border-green-400/20 bg-black/80 p-6 transition-all duration-300 hover:border-green-400/40 hover:bg-green-400/5'>
         {/* Logo in top right */}
-        {project.logo && (
+        {logoUrl && (
           <div className='absolute top-4 right-4'>
             <Image
-              src={project.logo}
+              src={logoUrl}
               alt={`${project.title ?? project.projectName} logo`}
               width={60}
               height={60}

--- a/src/components/organisms/landing-sections/ProjectsPreviewSection.test.tsx
+++ b/src/components/organisms/landing-sections/ProjectsPreviewSection.test.tsx
@@ -15,6 +15,10 @@ vi.mock('@/apiClients', async () => {
       loading: true,
       error: undefined,
     })),
+    useResolvedFileUrl: (key?: string | null) => ({
+      url: key ?? undefined,
+      loading: false,
+    }),
   }
 })
 

--- a/src/components/templates/ProjectDetailsTemplate.test.tsx
+++ b/src/components/templates/ProjectDetailsTemplate.test.tsx
@@ -8,7 +8,6 @@ import { ProjectDetailsTemplate } from './ProjectDetailsTemplate'
 
 // Mock only the API clients that ProjectDetailsTemplate actually uses
 const mockGetMe = vi.fn()
-const mockGetFile = vi.fn()
 
 // Mock the specific functions we need, let the rest use real implementations
 const mockProvisionProjectRepo = vi.fn()
@@ -18,7 +17,10 @@ vi.mock('@/apiClients', async () => {
   return {
     ...actual,
     useGetMe: () => mockGetMe(),
-    useGetFile: () => mockGetFile(),
+    useResolvedFileUrl: (key?: string | null) => ({
+      url: key ?? undefined,
+      loading: false,
+    }),
     useProvisionProjectRepo: () => [mockProvisionProjectRepo, { loading: false }],
     useUpdateProject: () => [vi.fn(), { loading: false }],
   }
@@ -66,10 +68,6 @@ describe('ProjectDetailsTemplate', () => {
     // Set up default mock behavior
     mockGetMe.mockReturnValue({
       data: { me: null },
-      loading: false,
-    })
-    mockGetFile.mockReturnValue({
-      data: null,
       loading: false,
     })
   })

--- a/src/components/templates/ProjectDetailsTemplate.test.tsx
+++ b/src/components/templates/ProjectDetailsTemplate.test.tsx
@@ -8,6 +8,7 @@ import { ProjectDetailsTemplate } from './ProjectDetailsTemplate'
 
 // Mock only the API clients that ProjectDetailsTemplate actually uses
 const mockGetMe = vi.fn()
+const mockUseResolvedFileUrl = vi.fn()
 
 // Mock the specific functions we need, let the rest use real implementations
 const mockProvisionProjectRepo = vi.fn()
@@ -17,10 +18,7 @@ vi.mock('@/apiClients', async () => {
   return {
     ...actual,
     useGetMe: () => mockGetMe(),
-    useResolvedFileUrl: (key?: string | null) => ({
-      url: key ?? undefined,
-      loading: false,
-    }),
+    useResolvedFileUrl: (key?: string | null) => mockUseResolvedFileUrl(key),
     useProvisionProjectRepo: () => [mockProvisionProjectRepo, { loading: false }],
     useUpdateProject: () => [vi.fn(), { loading: false }],
   }
@@ -70,6 +68,10 @@ describe('ProjectDetailsTemplate', () => {
       data: { me: null },
       loading: false,
     })
+    mockUseResolvedFileUrl.mockImplementation((key?: string | null) => ({
+      url: key ?? undefined,
+      loading: false,
+    }))
   })
 
   it('renders project header with correct information', () => {
@@ -187,6 +189,15 @@ describe('ProjectDetailsTemplate', () => {
     const projectWithoutLogo = { ...mockProject, logo: undefined }
     render(<ProjectDetailsTemplate project={projectWithoutLogo} />)
 
+    expect(screen.queryByAltText('Test Project logo')).not.toBeInTheDocument()
+  })
+
+  it('shows a loading state instead of the no-logo fallback while the logo URL resolves', () => {
+    mockUseResolvedFileUrl.mockReturnValue({ url: undefined, loading: true })
+
+    render(<ProjectDetailsTemplate project={mockProject} />)
+
+    expect(screen.getByText('Loading logo...')).toBeInTheDocument()
     expect(screen.queryByAltText('Test Project logo')).not.toBeInTheDocument()
   })
 

--- a/src/components/templates/ProjectDetailsTemplate.tsx
+++ b/src/components/templates/ProjectDetailsTemplate.tsx
@@ -2,12 +2,12 @@
 
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
-import { startTransition, useEffect, useOptimistic, useRef, useState } from 'react'
+import { startTransition, useOptimistic, useState } from 'react'
 import { FaPencilAlt, FaRegStar, FaStar } from 'react-icons/fa'
 
 import type { Project } from '@/graphql/generated/graphql'
 
-import { useGetFile, useGetMe, useProvisionProjectRepo, useUpdateProject } from '@/apiClients'
+import { useGetMe, useProvisionProjectRepo, useResolvedFileUrl, useUpdateProject } from '@/apiClients'
 import {
   BackButton,
   Button,
@@ -48,32 +48,15 @@ export const ProjectDetailsTemplate = ({
   const [optimisticStatus, setOptimisticStatus] = useOptimistic(project.status)
   const [optimisticProgress, setOptimisticProgress] = useOptimistic(project.progressPercentage)
   const [showLogoUpload, setShowLogoUpload] = useState(false)
-  const [currentLogoUrl, setCurrentLogoUrl] = useState<string | null>(
-    project.logo || null
-  )
+  // Only set once a fresh upload finalizes; the stored project.logo (public
+  // asset path or R2 key) is otherwise resolved to a URL below.
+  const [currentLogoUrl, setCurrentLogoUrl] = useState<string | null>(null)
   const [liveUrl, setLiveUrl] = useState<string>(project.liveUrl || '')
   const [editingLiveUrl, setEditingLiveUrl] = useState(false)
   const [liveUrlDraft, setLiveUrlDraft] = useState<string>(project.liveUrl || '')
-  const setCurrentLogoUrlRef = useRef(setCurrentLogoUrl)
 
-  // Check if the project logo is a public URL or a storage key
-  const isPublicUrl = (url?: string | null) =>
-    !!url && (/^https?:\/\//.test(url) || url.startsWith('/assets/'))
-
-  // Use the current logo URL if set, otherwise fall back to the project logo
-  const displayLogo =
-    currentLogoUrl || (isPublicUrl(project.logo) ? project.logo : undefined)
-
-  // Get download URL for non-public storage keys
-  const shouldFetchFile = project.logo && !isPublicUrl(project.logo)
-  const { data: fileData } = useGetFile(shouldFetchFile ? project.logo : '')
-
-  // Update current logo URL when file data is loaded
-  useEffect(() => {
-    if (shouldFetchFile && fileData?.file?.downloadUrl && !currentLogoUrl) {
-      setCurrentLogoUrlRef.current(fileData.file.downloadUrl)
-    }
-  }, [shouldFetchFile, fileData?.file?.downloadUrl, currentLogoUrl])
+  const { url: resolvedLogoUrl } = useResolvedFileUrl(project.logo)
+  const displayLogo = currentLogoUrl || resolvedLogoUrl
 
   // Check if current user can edit this project (is client or developer)
   // Only check after user data is loaded to avoid showing upload component briefly
@@ -181,14 +164,14 @@ export const ProjectDetailsTemplate = ({
     <CleanPageTemplate>
       <BackButton useBack text='BACK' />
       {canManageFeatured && (
-        <div className='fixed top-24 right-0 left-0 z-40'>
+        <div className='pointer-events-none fixed top-24 right-0 left-0 z-40'>
           <div className='container mx-auto px-4'>
             <div className='flex justify-end'>
               <button
                 type='button'
                 onClick={handleToggleFeatured}
                 disabled={updatingFeatured}
-                className='cursor-pointer text-green-600 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-40'
+                className='pointer-events-auto cursor-pointer text-green-600 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-40'
                 title={featured ? 'Remove from featured' : 'Add to featured'}
                 aria-label={featured ? 'Remove from featured' : 'Add to featured'}
                 aria-pressed={featured}

--- a/src/components/templates/ProjectDetailsTemplate.tsx
+++ b/src/components/templates/ProjectDetailsTemplate.tsx
@@ -55,7 +55,9 @@ export const ProjectDetailsTemplate = ({
   const [editingLiveUrl, setEditingLiveUrl] = useState(false)
   const [liveUrlDraft, setLiveUrlDraft] = useState<string>(project.liveUrl || '')
 
-  const { url: resolvedLogoUrl } = useResolvedFileUrl(project.logo)
+  const { url: resolvedLogoUrl, loading: logoResolving } = useResolvedFileUrl(
+    project.logo
+  )
   const displayLogo = currentLogoUrl || resolvedLogoUrl
 
   // Check if current user can edit this project (is client or developer)
@@ -235,12 +237,12 @@ export const ProjectDetailsTemplate = ({
                       </button>
                     )}
                   </div>
-                ) : meLoading ? (
+                ) : meLoading || logoResolving ? (
                   <div className='flex h-[300px] w-[300px] items-center justify-center rounded-lg border border-green-400/20 bg-black/80 p-8'>
                     <div className='text-center'>
                       <div className='mx-auto h-8 w-8 animate-spin rounded-full border-2 border-green-400 border-t-transparent'></div>
                       <p className='mt-2 font-mono text-xs text-green-400/70'>
-                        Checking permissions...
+                        {meLoading ? 'Checking permissions...' : 'Loading logo...'}
                       </p>
                     </div>
                   </div>

--- a/src/graphql/resolvers/FileResolver.test.ts
+++ b/src/graphql/resolvers/FileResolver.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MAX_FILE_SIZE } from '@/constants/file'
 import { FileResolver } from '@/graphql/resolvers/FileResolver'
 import { Environment, UserRole } from '@/graphql/schema'
-import { Env } from '@/libs/Env'
 import { createMockUser } from '@/tests/mocks/auth'
 import { createMockProject } from '@/tests/mocks/projects'
 import {
@@ -26,6 +25,7 @@ const createMockFile = (overrides = {}) => ({
   fileSize: 1024,
   uploadedBy: 'user-1',
   projectId: 'project-1',
+  environment: Environment.DEV,
   uploadedAt: new Date('2024-01-01'),
   ...overrides,
 })
@@ -61,7 +61,7 @@ describe('FileResolver', () => {
 
       expect(result).toEqual(mockFiles)
       expect(mockFileService.listFiles).toHaveBeenCalledWith(
-        'dev/projects/project-1/'
+        'projects/project-1/'
       )
     })
 
@@ -83,7 +83,7 @@ describe('FileResolver', () => {
         UserRole.Admin
       )
       expect(mockFileService.listFiles).toHaveBeenCalledWith(
-        'dev/users/user-2/'
+        'users/user-2/'
       )
     })
 
@@ -101,7 +101,7 @@ describe('FileResolver', () => {
       expect(result).toEqual(mockFiles)
       expect(mockUserService.checkPermission).not.toHaveBeenCalled()
       expect(mockFileService.listFiles).toHaveBeenCalledWith(
-        'dev/users/user-1/'
+        'users/user-1/'
       )
     })
 
@@ -256,9 +256,9 @@ describe('FileResolver', () => {
       mockProjectService.getProjectById.mockResolvedValue(mockProject)
       mockFileService.generateProjectLogoPresignedUpload.mockResolvedValue({
         uploadUrl: 'https://r2.example.com/put',
-        key: 'dev/projects/project-1/1_logo.jpg',
+        key: 'projects/project-1/1_logo.jpg',
         metadata: {
-          key: 'dev/projects/project-1/1_logo.jpg',
+          key: 'projects/project-1/1_logo.jpg',
           fileName: 'logo.jpg',
           originalFileName: 'logo.jpg',
           fileSize: 1024,
@@ -276,7 +276,7 @@ describe('FileResolver', () => {
       )
 
       expect(result.uploadUrl).toBe('https://r2.example.com/put')
-      expect(result.key).toBe('dev/projects/project-1/1_logo.jpg')
+      expect(result.key).toBe('projects/project-1/1_logo.jpg')
       expect(result.projectId).toBe('project-1')
       expect(
         mockFileService.generateProjectLogoPresignedUpload
@@ -389,8 +389,8 @@ describe('FileResolver', () => {
   describe('finalizeProjectLogoUpload', () => {
     it('should finalize logo and return download URL', async () => {
       const currentUser = createMockUser()
-      const logoKey = `${Env.APP_ENV}/projects/project-1/1_logo.jpg`
-      const oldLogoKey = `${Env.APP_ENV}/projects/project-1/old.png`
+      const logoKey = 'projects/project-1/1_logo.jpg'
+      const oldLogoKey = 'projects/project-1/old.png'
       const mockProject = createMockProject({
         id: 'project-1',
         logo: oldLogoKey,
@@ -448,7 +448,7 @@ describe('FileResolver', () => {
       await expect(
         fileResolver.finalizeProjectLogoUpload(
           'project-1',
-          `${Env.APP_ENV}/projects/other-project/x.jpg`
+          'projects/other-project/x.jpg'
         )
       ).rejects.toThrow('Invalid logo key')
     })
@@ -458,7 +458,7 @@ describe('FileResolver', () => {
       mockUserService.getCurrentUserWithAuth.mockResolvedValue(currentUser)
       mockProjectService.getProjectById.mockResolvedValue(createMockProject())
 
-      const badKey = `${Env.APP_ENV}/projects/project-1/../evil/x.jpg`
+      const badKey = 'projects/project-1/../evil/x.jpg'
 
       await expect(
         fileResolver.finalizeProjectLogoUpload('project-1', badKey)
@@ -467,7 +467,7 @@ describe('FileResolver', () => {
 
     it('should throw when object head is missing', async () => {
       const currentUser = createMockUser()
-      const logoKey = `${Env.APP_ENV}/projects/project-1/k.jpg`
+      const logoKey = 'projects/project-1/k.jpg'
       mockUserService.getCurrentUserWithAuth.mockResolvedValue(currentUser)
       mockProjectService.getProjectById.mockResolvedValue(createMockProject())
       mockFileService.getObjectHeadInfo.mockResolvedValue(null)
@@ -479,7 +479,7 @@ describe('FileResolver', () => {
 
     it('should throw when object is larger than max', async () => {
       const currentUser = createMockUser()
-      const logoKey = `${Env.APP_ENV}/projects/project-1/k.jpg`
+      const logoKey = 'projects/project-1/k.jpg'
       mockUserService.getCurrentUserWithAuth.mockResolvedValue(currentUser)
       mockProjectService.getProjectById.mockResolvedValue(createMockProject())
       mockFileService.getObjectHeadInfo.mockResolvedValue({
@@ -494,7 +494,7 @@ describe('FileResolver', () => {
 
     it('should throw when buffer range is empty', async () => {
       const currentUser = createMockUser()
-      const logoKey = `${Env.APP_ENV}/projects/project-1/k.jpg`
+      const logoKey = 'projects/project-1/k.jpg'
       mockUserService.getCurrentUserWithAuth.mockResolvedValue(currentUser)
       mockProjectService.getProjectById.mockResolvedValue(createMockProject())
       mockFileService.getObjectHeadInfo.mockResolvedValue({
@@ -510,7 +510,7 @@ describe('FileResolver', () => {
 
     it('should throw when detected type is not allowed', async () => {
       const currentUser = createMockUser()
-      const logoKey = `${Env.APP_ENV}/projects/project-1/k.jpg`
+      const logoKey = 'projects/project-1/k.jpg'
       mockUserService.getCurrentUserWithAuth.mockResolvedValue(currentUser)
       mockProjectService.getProjectById.mockResolvedValue(createMockProject())
       mockFileService.getObjectHeadInfo.mockResolvedValue({
@@ -532,7 +532,7 @@ describe('FileResolver', () => {
 
     it('should throw when getFileMetadata returns null', async () => {
       const currentUser = createMockUser()
-      const logoKey = `${Env.APP_ENV}/projects/project-1/k.jpg`
+      const logoKey = 'projects/project-1/k.jpg'
       mockUserService.getCurrentUserWithAuth.mockResolvedValue(currentUser)
       mockProjectService.getProjectById.mockResolvedValue(createMockProject())
       mockFileService.getObjectHeadInfo.mockResolvedValue({
@@ -557,7 +557,7 @@ describe('FileResolver', () => {
 
     it('should not delete storage when old logo key equals new key', async () => {
       const currentUser = createMockUser()
-      const logoKey = `${Env.APP_ENV}/projects/project-1/1_logo.jpg`
+      const logoKey = 'projects/project-1/1_logo.jpg'
       const mockProject = createMockProject({
         id: 'project-1',
         logo: logoKey,
@@ -659,7 +659,7 @@ describe('FileResolver', () => {
       })
 
       it('should return presigned URL for R2 path', async () => {
-        const file = createMockFile({ key: 'dev/projects/project-1/logo.jpg' })
+        const file = createMockFile({ key: 'projects/project-1/logo.jpg' })
         const currentUser = createMockUser()
 
         mockUserService.getCurrentUserWithAuth.mockResolvedValue(currentUser)
@@ -678,7 +678,7 @@ describe('FileResolver', () => {
 
       it('should throw error when access denied', async () => {
         const file = createMockFile({
-          key: 'dev/projects/project-1/logo.jpg',
+          key: 'projects/project-1/logo.jpg',
           uploadedBy: 'other-user',
           projectId: null,
         })

--- a/src/graphql/resolvers/FileResolver.ts
+++ b/src/graphql/resolvers/FileResolver.ts
@@ -14,13 +14,11 @@ import type { FileService, ProjectService, UserService } from '@/services'
 
 import { ALLOWED_IMAGE_TYPES, MAX_FILE_SIZE } from '@/constants/file'
 import {
-  Environment,
   File,
   FileFilterInput,
   ProjectLogoUploadResult,
   UserRole,
 } from '@/graphql/schema'
-import { Env } from '@/libs/Env'
 import { logger } from '@/libs/Logger'
 import {
   isAllowedImageContentType,
@@ -41,16 +39,15 @@ export class FileResolver {
     filter?: FileFilterInput
   ) {
     const currentUser = await this.userService.getCurrentUserWithAuth()
-    const env = filter?.environment ?? Environment.DEV
     let prefix = ''
     if (filter?.projectId) {
-      prefix = `${env.toLowerCase()}/projects/${filter.projectId}/`
+      prefix = `projects/${filter.projectId}/`
     } else if (filter?.userId) {
       // Only allow users to list their own files, or admins to list any user's files
       if (filter.userId !== currentUser.id) {
         this.userService.checkPermission(currentUser, UserRole.Admin)
       }
-      prefix = `${env.toLowerCase()}/users/${filter.userId}/`
+      prefix = `users/${filter.userId}/`
     }
 
     // Get list of file keys
@@ -61,7 +58,15 @@ export class FileResolver {
       fileKeys.map((key: string) => this.fileService.getFileMetadata(key))
     )
 
-    return fileMetadata.filter(Boolean)
+    const results = fileMetadata.filter(
+      (file): file is NonNullable<typeof file> => file !== null
+    )
+    // The bucket is already environment-scoped, so this only matters if a
+    // caller explicitly wants to cross-check recorded upload metadata.
+    if (filter?.environment) {
+      return results.filter((file) => file.environment === filter.environment)
+    }
+    return results
   }
 
   @Query(() => File, { nullable: true })
@@ -119,8 +124,7 @@ export class FileResolver {
       this.userService.checkPermission(currentUser, UserRole.Admin)
     }
 
-    const env = Env.APP_ENV
-    const files = await this.fileService.listFiles(`${env}/users/${userId}/`)
+    const files = await this.fileService.listFiles(`users/${userId}/`)
 
     // Get metadata for each file
     const fileMetadata = await Promise.all(
@@ -215,7 +219,7 @@ export class FileResolver {
       throw new Error('Project not found or access denied')
     }
 
-    const expectedPrefix = `${Env.APP_ENV}/projects/${projectId}/`
+    const expectedPrefix = `projects/${projectId}/`
     if (!key.startsWith(expectedPrefix)) {
       throw new Error('Invalid logo key')
     }

--- a/src/services/FileService.test.ts
+++ b/src/services/FileService.test.ts
@@ -64,7 +64,6 @@ describe('FileService', () => {
       R2_ACCESS_KEY_ID: 'test-access-key',
       R2_SECRET_ACCESS_KEY: 'test-secret-key',
       R2_BUCKET_NAME: 'test-bucket',
-      APP_ENV: 'dev',
     })
     // Initialize mockS3Send before creating FileService
     mockS3Send = vi.fn()
@@ -98,9 +97,7 @@ describe('FileService', () => {
       const result = await fileService.generatePresignedUploadUrl(mockFileInput)
 
       expect(result.uploadUrl).toBe('https://signed-url.com')
-      expect(result.key).toMatch(
-        /dev\/projects\/project-123\/\d+_test-file\.jpg/
-      )
+      expect(result.key).toMatch(/projects\/project-123\/\d+_test-file\.jpg/)
       expect(result.metadata).toEqual({
         fileName: mockFileInput.fileName,
         originalFileName: mockFileInput.originalFileName,
@@ -111,7 +108,7 @@ describe('FileService', () => {
         environment: mockFileInput.environment,
         uploadedAt: expect.any(Date),
         key: expect.stringMatching(
-          /dev\/projects\/project-123\/\d+_test-file\.jpg/
+          /projects\/project-123\/\d+_test-file\.jpg/
         ),
       })
     })
@@ -123,7 +120,7 @@ describe('FileService', () => {
       const result = await fileService.generatePresignedUploadUrl(userFileInput)
 
       expect(result.uploadUrl).toBe('https://signed-url.com')
-      expect(result.key).toMatch(/dev\/users\/user-123\/\d+_test-file\.jpg/)
+      expect(result.key).toMatch(/users\/user-123\/\d+_test-file\.jpg/)
       expect(result.metadata.projectId).toBeUndefined()
     })
 
@@ -155,7 +152,7 @@ describe('FileService', () => {
       })
 
       expect(result.uploadUrl).toBe('https://presigned-put.example')
-      expect(result.key).toMatch(/^dev\/projects\/project-1\/\d+_logo\.\.png$/)
+      expect(result.key).toMatch(/^projects\/project-1\/\d+_logo\.\.png$/)
       expect(result.metadata.fileName).toBe('logo..png')
       expect(result.metadata.contentType).toBe('image/png')
       expect(result.metadata.fileSize).toBe(2048)
@@ -180,8 +177,8 @@ describe('FileService', () => {
       expect(putInput.Metadata).toBeUndefined()
     })
 
-    it('should use PROD environment in metadata when APP_ENV is prod', async () => {
-      Object.assign(Env, { APP_ENV: 'prod' })
+    it('should use PROD environment in metadata when R2_BUCKET_NAME is prod', async () => {
+      Object.assign(Env, { R2_BUCKET_NAME: 'prod' })
       mockGetSignedUrl.mockResolvedValue('https://put')
       fileService = new FileService()
 
@@ -195,9 +192,9 @@ describe('FileService', () => {
       })
 
       expect(result.metadata.environment).toBe(Environment.PROD)
-      expect(result.key).toMatch(/^prod\/projects\/p1\//)
+      expect(result.key).toMatch(/^projects\/p1\//)
 
-      Object.assign(Env, { APP_ENV: 'dev' })
+      Object.assign(Env, { R2_BUCKET_NAME: 'test-bucket' })
       fileService = new FileService()
     })
   })

--- a/src/services/FileService.test.ts
+++ b/src/services/FileService.test.ts
@@ -97,7 +97,7 @@ describe('FileService', () => {
       const result = await fileService.generatePresignedUploadUrl(mockFileInput)
 
       expect(result.uploadUrl).toBe('https://signed-url.com')
-      expect(result.key).toMatch(/projects\/project-123\/\d+_test-file\.jpg/)
+      expect(result.key).toMatch(/^projects\/project-123\/\d+_test-file\.jpg$/)
       expect(result.metadata).toEqual({
         fileName: mockFileInput.fileName,
         originalFileName: mockFileInput.originalFileName,
@@ -108,7 +108,7 @@ describe('FileService', () => {
         environment: mockFileInput.environment,
         uploadedAt: expect.any(Date),
         key: expect.stringMatching(
-          /projects\/project-123\/\d+_test-file\.jpg/
+          /^projects\/project-123\/\d+_test-file\.jpg$/
         ),
       })
     })
@@ -120,8 +120,24 @@ describe('FileService', () => {
       const result = await fileService.generatePresignedUploadUrl(userFileInput)
 
       expect(result.uploadUrl).toBe('https://signed-url.com')
-      expect(result.key).toMatch(/users\/user-123\/\d+_test-file\.jpg/)
+      expect(result.key).toMatch(/^users\/user-123\/\d+_test-file\.jpg$/)
       expect(result.metadata.projectId).toBeUndefined()
+    })
+
+    it('derives environment from the bucket, not the caller-supplied input', async () => {
+      Object.assign(Env, { R2_BUCKET_NAME: 'prod' })
+      fileService = new FileService()
+      mockGetSignedUrl.mockResolvedValue('https://signed-url.com')
+
+      const result = await fileService.generatePresignedUploadUrl({
+        ...mockFileInput,
+        environment: Environment.DEV,
+      })
+
+      expect(result.metadata.environment).toBe(Environment.PROD)
+
+      Object.assign(Env, { R2_BUCKET_NAME: 'test-bucket' })
+      fileService = new FileService()
     })
 
     it('should sanitize file names', async () => {
@@ -419,6 +435,29 @@ describe('FileService', () => {
         uploadedAt: expect.any(Date),
         key: 'test-key',
       })
+    })
+
+    it('defaults environment to the bucket, not DEV, when metadata omits it', async () => {
+      // Logo PUTs never write S3 Metadata, so this is the real-world case
+      // that fed this fallback for uploads to the prod bucket.
+      Object.assign(Env, { R2_BUCKET_NAME: 'prod' })
+      fileService = new FileService()
+      mockS3Send.mockResolvedValue({
+        Metadata: {
+          fileName: 'test.jpg',
+          fileSize: '1024',
+          contentType: 'image/jpeg',
+          uploadedBy: 'user-123',
+        },
+        ContentType: 'image/jpeg',
+      })
+
+      const result = await fileService.getFileMetadata('test-key')
+
+      expect(result?.environment).toBe(Environment.PROD)
+
+      Object.assign(Env, { R2_BUCKET_NAME: 'test-bucket' })
+      fileService = new FileService()
     })
 
     it('should return null on error', async () => {

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -48,8 +48,12 @@ export class FileService {
 
   // The R2 bucket itself is environment-scoped (R2_BUCKET_NAME), so this
   // reflects which bucket we're actually talking to rather than APP_ENV.
+  // Contract: the production bucket must be named "prod" (case-insensitive)
+  // for uploads to resolve to Environment.PROD; any other bucket name is DEV.
   private resolveEnvironment(): Environment {
-    return this.bucketName === 'prod' ? Environment.PROD : Environment.DEV
+    return this.bucketName.toLowerCase() === 'prod'
+      ? Environment.PROD
+      : Environment.DEV
   }
 
   /**
@@ -180,6 +184,10 @@ export class FileService {
     }
   }> {
     const key = this.generateKey(options)
+    // Derive from the bucket rather than trusting the caller-supplied
+    // options.environment, so stored metadata can't disagree with the bucket
+    // it's actually stored in.
+    const environment = this.resolveEnvironment()
     const metadata = {
       key,
       fileName: options.fileName,
@@ -188,7 +196,7 @@ export class FileService {
       contentType: options.contentType,
       uploadedBy: options.userId,
       projectId: options.projectId || undefined,
-      environment: options.environment || Environment.DEV,
+      environment,
       uploadedAt: new Date(),
     }
 
@@ -203,7 +211,7 @@ export class FileService {
         filesize: options.fileSize.toString(),
         uploadedby: options.userId,
         projectid: options.projectId || '',
-        environment: options.environment || Environment.DEV,
+        environment,
         uploadedat: new Date().toISOString(),
       },
     })
@@ -327,7 +335,9 @@ export class FileService {
         contentType: response.ContentType || '',
         uploadedBy: meta.uploadedby || '',
         projectId: meta.projectid || undefined,
-        environment: (meta.environment as Environment) || Environment.DEV,
+        // Logo PUTs never write S3 Metadata (see generateProjectLogoPresignedUpload),
+        // so fall back to the bucket's environment rather than hardcoding DEV.
+        environment: (meta.environment as Environment) || this.resolveEnvironment(),
         uploadedAt: new Date(meta.uploadedat || Date.now()),
       }
     } catch (error) {

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -46,8 +46,10 @@ export class FileService {
     this.bucketName = Env.R2_BUCKET_NAME
   }
 
-  private appEnvToEnvironment(): Environment {
-    return Env.APP_ENV === 'prod' ? Environment.PROD : Environment.DEV
+  // The R2 bucket itself is environment-scoped (R2_BUCKET_NAME), so this
+  // reflects which bucket we're actually talking to rather than APP_ENV.
+  private resolveEnvironment(): Environment {
+    return this.bucketName === 'prod' ? Environment.PROD : Environment.DEV
   }
 
   /**
@@ -78,8 +80,7 @@ export class FileService {
       options
     const timestamp = Date.now()
     const sanitizedFileName = fileName.replace(/[^a-z0-9.-]/gi, '_')
-    const env = Env.APP_ENV
-    const key = `${env}/projects/${projectId}/${timestamp}_${sanitizedFileName}`
+    const key = `projects/${projectId}/${timestamp}_${sanitizedFileName}`
 
     const metadata = {
       key,
@@ -87,7 +88,7 @@ export class FileService {
       originalFileName,
       fileSize,
       contentType,
-      environment: this.appEnvToEnvironment(),
+      environment: this.resolveEnvironment(),
       uploadedAt: new Date(),
     }
 
@@ -153,13 +154,12 @@ export class FileService {
   private generateKey(options: FileUploadInput & { userId: string }): string {
     const timestamp = Date.now()
     const sanitizedFileName = options.fileName.replace(/[^a-z0-9.-]/gi, '_')
-    const env = options.environment || Environment.DEV
 
     if (options.projectId) {
-      return `${env.toLowerCase()}/projects/${options.projectId}/${timestamp}_${sanitizedFileName}`
+      return `projects/${options.projectId}/${timestamp}_${sanitizedFileName}`
     }
 
-    return `${env.toLowerCase()}/users/${options.userId}/${timestamp}_${sanitizedFileName}`
+    return `users/${options.userId}/${timestamp}_${sanitizedFileName}`
   }
 
   async generatePresignedUploadUrl(

--- a/src/utils/File.test.ts
+++ b/src/utils/File.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   isAllowedImageContentType,
+  isPublicUrl,
   normalizeImageContentType,
 } from '@/utils/File'
 
@@ -25,6 +26,27 @@ describe('File utils', () => {
 
     it('rejects non-image types', () => {
       expect(isAllowedImageContentType('application/pdf')).toBe(false)
+    })
+  })
+
+  describe('isPublicUrl', () => {
+    it('accepts http(s) URLs', () => {
+      expect(isPublicUrl('https://example.com/logo.png')).toBe(true)
+      expect(isPublicUrl('http://example.com/logo.png')).toBe(true)
+    })
+
+    it('accepts local asset paths', () => {
+      expect(isPublicUrl('/assets/logo.png')).toBe(true)
+    })
+
+    it('rejects bare R2 object keys', () => {
+      expect(isPublicUrl('projects/123/1700000000000_logo.png')).toBe(false)
+    })
+
+    it('rejects null/undefined/empty', () => {
+      expect(isPublicUrl(null)).toBe(false)
+      expect(isPublicUrl(undefined)).toBe(false)
+      expect(isPublicUrl('')).toBe(false)
     })
   })
 })

--- a/src/utils/File.ts
+++ b/src/utils/File.ts
@@ -10,3 +10,10 @@ export function isAllowedImageContentType(ct: string): boolean {
   const n = normalizeImageContentType(ct)
   return ALLOWED_IMAGE_TYPES.includes(n)
 }
+
+// A project logo/file field is either a browser-loadable URL (public asset, or a
+// presigned URL cached in local state) or a bare R2 object key that needs resolving
+// via the `file` query before it can be used as an <Image> src.
+export function isPublicUrl(url?: string | null): boolean {
+  return !!url && (/^https?:\/\//.test(url) || url.startsWith('/assets/'))
+}


### PR DESCRIPTION
## Summary
- R2 buckets are already environment-scoped via `R2_BUCKET_NAME` (`dev` vs `prod`), so also prefixing every object key with `${Env.APP_ENV}/` was redundant.
- `APP_ENV` defaults to `'dev'` and is never actually set to `'prod'` in the production environment, so every prod upload was keyed as `dev/projects/...` inside the *correct* prod bucket — meaning prod uploads have been landing under a spurious `dev/` folder in the prod bucket.
- Removes the env segment from generated keys (`FileService.generateProjectLogoPresignedUpload`, `generateKey`) and from prefix matching/listing (`FileResolver.files`, `userFiles`, `finalizeProjectLogoUpload`).
- `environment` metadata (still recorded per file) now derives from the R2 bucket name instead of `APP_ENV`, so it stays correct without needing `APP_ENV` set anywhere.

New key shape: `projects/{projectId}/{timestamp}_{fileName}` and `users/{userId}/{timestamp}_{fileName}` (no env prefix) — bucket separation alone now indicates dev vs prod.

## Test plan
- [x] `npx vitest run src/services/FileService.test.ts src/graphql/resolvers/FileResolver.test.ts src/apiClients/fileApiClient.test.ts` — 71 passed
- [x] `npx vitest run` (full suite) — 805 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [ ] Existing objects in the dev bucket under root `projects/` (pre-dating the original env-prefix change) and in the prod bucket under `dev/` (caused by this bug) still need manual migration/cleanup in R2 — out of scope for this PR, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes production object key layout and fixes a prod mis-keying bug; existing R2 objects and DB-stored keys may still point at old paths until a separate migration runs.
> 
> **Overview**
> **R2 object keys no longer include an `APP_ENV` path segment** (`dev/` or `prod/`). Keys are now `projects/{id}/…` and `users/{id}/…` because each environment already uses its own bucket via `R2_BUCKET_NAME`. File metadata `environment` is derived from the bucket name (production bucket must be named `prod`) instead of `APP_ENV`, which was never set to `prod` in production and caused prod uploads to land under `dev/` inside the prod bucket.
> 
> **GraphQL file listing and logo finalize** paths were updated to match the new key shape; optional `filter.environment` still filters by stored metadata when provided.
> 
> **UI** adds shared `isPublicUrl` and `useResolvedFileUrl` so project logos stored as bare R2 keys resolve through the `file` query before rendering in `ProjectCard` and `ProjectDetailsTemplate`, with a loading state while resolving. Project details also tweaks the featured-star overlay so it does not block clicks (`pointer-events`).
> 
> **Docs:** `CLAUDE.md` gains Drizzle migration workflow (including data-only and cross-system scripts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e861bd6b499bd6ceeda9ecf0403f309eb40c7f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated project and user file storage to use consistent, environment-independent paths.
  * Project logos, uploads, listings, and download links now follow the updated storage structure.
  * File listings can still be filtered by environment metadata where applicable.
  * Environment information is now associated with the configured storage bucket rather than storage path prefixes.
  * Added automatic handling for public URLs and private file links.
  * Project images now load correctly from either public URLs or private storage.
* **Documentation**
  * Added guidance for managing database schema migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->