### PR TITLE
feat(project-request): expand ProjectFeature enum + advanced options section

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -6,6 +6,7 @@ const config: KnipConfig = {
     'tests/**/*.ts',
     'src/apiClients/**/*.ts', // Ignore API clients - used by GraphQL codegen
     'src/graphql/**/*.ts', // Ignore GraphQL files - used by codegen
+    'src/libs/featurePricing.ts', // Admin-only reference data, consumed by InvoiceService (not yet built)
   ],
   // Dependencies to ignore during analysis
   ignoreDependencies: [

--- a/migrations/0018_gifted_venom.sql
+++ b/migrations/0018_gifted_venom.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "project_requests" ADD COLUMN "features" json;

--- a/migrations/meta/0018_snapshot.json
+++ b/migrations/meta/0018_snapshot.json
@@ -1,0 +1,1255 @@
+{
+  "id": "dd8a4b22-ce4d-4d00-918b-6ba8de229882",
+  "prevId": "20907411-c8f7-4fab-b780-9af1caa4633b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_name": {
+          "name": "domain_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registrar": {
+          "name": "registrar",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'godaddy'"
+        },
+        "status": {
+          "name": "status",
+          "type": "domain_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "registration_date": {
+          "name": "registration_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_renew": {
+          "name": "auto_renew",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "nameservers": {
+          "name": "nameservers",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_records": {
+          "name": "dns_records",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "godaddy_domain_id": {
+          "name": "godaddy_domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_certificate": {
+          "name": "ssl_certificate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ssl_expiration_date": {
+          "name": "ssl_expiration_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_domains_project_id": {
+          "name": "idx_domains_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_domains_user_id": {
+          "name": "idx_domains_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domains_project_id_projects_id_fk": {
+          "name": "domains_project_id_projects_id_fk",
+          "tableFrom": "domains",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domains_user_id_users_id_fk": {
+          "name": "domains_user_id_users_id_fk",
+          "tableFrom": "domains",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domains_domain_name_unique": {
+          "name": "domains_domain_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_files": {
+      "name": "project_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_file_name": {
+          "name": "original_file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_client_visible": {
+          "name": "is_client_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_files_project_id": {
+          "name": "idx_project_files_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_files_uploaded_by": {
+          "name": "idx_project_files_uploaded_by",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_files_project_id_projects_id_fk": {
+          "name": "project_files_project_id_projects_id_fk",
+          "tableFrom": "project_files",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_files_uploaded_by_users_id_fk": {
+          "name": "project_files_uploaded_by_users_id_fk",
+          "tableFrom": "project_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_collaborators": {
+      "name": "project_collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "can_view_files": {
+          "name": "can_view_files",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "can_upload_files": {
+          "name": "can_upload_files",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "can_manage_domains": {
+          "name": "can_manage_domains",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_collab_project_id": {
+          "name": "idx_project_collab_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_collab_user_id": {
+          "name": "idx_project_collab_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_collab_added_by": {
+          "name": "idx_project_collab_added_by",
+          "columns": [
+            {
+              "expression": "added_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_collaborators_project_id_projects_id_fk": {
+          "name": "project_collaborators_project_id_projects_id_fk",
+          "tableFrom": "project_collaborators",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_collaborators_user_id_users_id_fk": {
+          "name": "project_collaborators_user_id_users_id_fk",
+          "tableFrom": "project_collaborators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_collaborators_added_by_users_id_fk": {
+          "name": "project_collaborators_added_by_users_id_fk",
+          "tableFrom": "project_collaborators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_project_collaborator": {
+          "name": "uq_project_collaborator",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_requests": {
+      "name": "project_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget": {
+          "name": "budget",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeline": {
+          "name": "timeline",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "features": {
+          "name": "features",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_preference": {
+          "name": "contact_preference",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_info": {
+          "name": "additional_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "project_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_requests_user_id": {
+          "name": "idx_project_requests_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_requests_reviewed_by": {
+          "name": "idx_project_requests_reviewed_by",
+          "columns": [
+            {
+              "expression": "reviewed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_requests_user_id_users_id_fk": {
+          "name": "project_requests_user_id_users_id_fk",
+          "tableFrom": "project_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_requests_reviewed_by_users_id_fk": {
+          "name": "project_requests_reviewed_by_users_id_fk",
+          "tableFrom": "project_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "project_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "project_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "budget": {
+          "name": "budget",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_completion_date": {
+          "name": "estimated_completion_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_completion_date": {
+          "name": "actual_completion_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tech_stack": {
+          "name": "tech_stack",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "staging_url": {
+          "name": "staging_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neon_project_id": {
+          "name": "neon_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "features": {
+          "name": "features",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_url": {
+          "name": "live_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_notes": {
+          "name": "client_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_percentage": {
+          "name": "progress_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_request_id": {
+          "name": "idx_projects_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_client_id": {
+          "name": "idx_projects_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_developer_id": {
+          "name": "idx_projects_developer_id",
+          "columns": [
+            {
+              "expression": "developer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_request_id_project_requests_id_fk": {
+          "name": "projects_request_id_project_requests_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "project_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "projects_client_id_users_id_fk": {
+          "name": "projects_client_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_developer_id_users_id_fk": {
+          "name": "projects_developer_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "developer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.status_updates": {
+      "name": "status_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_status": {
+          "name": "old_status",
+          "type": "project_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "project_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress_percentage": {
+          "name": "progress_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_message": {
+          "name": "update_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_client_visible": {
+          "name": "is_client_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_status_updates_entity_type_id": {
+          "name": "idx_status_updates_entity_type_id",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_status_updates_updated_by": {
+          "name": "idx_status_updates_updated_by",
+          "columns": [
+            {
+              "expression": "updated_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "status_updates_updated_by_users_id_fk": {
+          "name": "status_updates_updated_by_users_id_fk",
+          "tableFrom": "status_updates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.domain_status": {
+      "name": "domain_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "expired",
+        "transferred",
+        "cancelled"
+      ]
+    },
+    "public.project_priority": {
+      "name": "project_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "medium",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.project_status": {
+      "name": "project_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "in_review",
+        "approved",
+        "in_progress",
+        "in_testing",
+        "ready_for_launch",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.project_type": {
+      "name": "project_type",
+      "schema": "public",
+      "values": [
+        "website",
+        "web_app",
+        "mobile_app",
+        "e_commerce",
+        "api",
+        "maintenance",
+        "consultation",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "client",
+        "developer",
+        "admin",
+        "super_admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1774239224162,
       "tag": "0017_set_project_requests_title_not_null",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1785997453570,
+      "tag": "0018_gifted_venom",
+      "breakpoints": true
     }
   ]
 }

--- a/src/apiClients/projectRequestApiClient.ts
+++ b/src/apiClients/projectRequestApiClient.ts
@@ -58,6 +58,7 @@ export const CREATE_PROJECT_REQUEST = gql`
         needsContentCreation
         needsSEO
       }
+      features
       contactPreference
       additionalInfo
       status

--- a/src/components/molecules/project-request/ProjectRequestForm.test.tsx
+++ b/src/components/molecules/project-request/ProjectRequestForm.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ProjectType } from '@/graphql/generated/graphql'
+import { ProjectFeature, ProjectType } from '@/graphql/generated/graphql'
 
 import { ProjectRequestForm } from './ProjectRequestForm'
 
@@ -45,6 +45,11 @@ vi.mock('@/validations', () => ({
     { value: 'email', label: 'Email' },
     { value: 'phone', label: 'Phone Call' },
     { value: 'text', label: 'Text Message' },
+  ],
+  projectFeatureOptions: [
+    { value: ProjectFeature.Database, label: 'Database' },
+    { value: ProjectFeature.Auth, label: 'Auth' },
+    { value: ProjectFeature.PaymentProcessing, label: 'Payment processing' },
   ],
 }))
 
@@ -319,6 +324,34 @@ describe('ProjectRequestForm', () => {
         screen.getByRole('button', { name: 'SUBMIT REQUEST' })
       ).toBeInTheDocument()
     })
+  })
+
+  it('renders advanced options collapsed by default', () => {
+    render(<ProjectRequestForm />)
+
+    expect(screen.getByText('▸ ADVANCED OPTIONS')).toBeInTheDocument()
+    expect(screen.queryByText('Database')).not.toBeInTheDocument()
+    expect(screen.queryByText('Auth')).not.toBeInTheDocument()
+  })
+
+  it('expands advanced options and toggles feature selection', () => {
+    render(<ProjectRequestForm />)
+
+    fireEvent.click(screen.getByText('▸ ADVANCED OPTIONS'))
+
+    expect(screen.getByText('▾ ADVANCED OPTIONS')).toBeInTheDocument()
+
+    const databaseCheckbox = screen.getByLabelText('Database')
+
+    expect(databaseCheckbox).not.toBeChecked()
+
+    fireEvent.click(databaseCheckbox)
+
+    expect(databaseCheckbox).toBeChecked()
+
+    fireEvent.click(databaseCheckbox)
+
+    expect(databaseCheckbox).not.toBeChecked()
   })
 
   it('handles budget field correctly', () => {

--- a/src/components/molecules/project-request/ProjectRequestForm.tsx
+++ b/src/components/molecules/project-request/ProjectRequestForm.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation'
 import { useRef, useState } from 'react'
 
+import type { ProjectFeature} from '@/graphql/generated/graphql';
 import type { ProjectRequestData } from '@/validations'
 
 import { useCreateProjectRequest } from '@/apiClients'
@@ -11,6 +12,7 @@ import { ProjectType } from '@/graphql/generated/graphql'
 import { Toast } from '@/libs/Toast'
 import {
   contactPreferenceOptions,
+  projectFeatureOptions,
   projectRequestSchema,
   projectTypeOptions,
 } from '@/validations'
@@ -25,6 +27,7 @@ const ErrorMessage = ({ error }: { error?: string }) => (
 export const ProjectRequestForm = () => {
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false)
   const [errors, setErrors] = useState<
     Partial<Record<keyof ProjectRequestData, string>>
   >({})
@@ -73,6 +76,7 @@ export const ProjectRequestForm = () => {
       needsContentCreation: false,
       needsSEO: false,
     },
+    features: [],
   })
 
   const handleInputChange = (
@@ -103,6 +107,18 @@ export const ProjectRequestForm = () => {
         [requirement]: checked,
       },
     }))
+  }
+
+  const handleFeatureChange = (feature: ProjectFeature, checked: boolean) => {
+    setFormData((prev) => {
+      const current = prev.features ?? []
+      return {
+        ...prev,
+        features: checked
+          ? [...current, feature]
+          : current.filter((f) => f !== feature),
+      }
+    })
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -324,6 +340,40 @@ export const ProjectRequestForm = () => {
             </label>
           ))}
         </div>
+      </div>
+
+      {/* Advanced Options Section - collapsed by default */}
+      <div className='space-y-4'>
+        <button
+          type='button'
+          onClick={() => setShowAdvancedOptions((prev) => !prev)}
+          className='font-mono text-lg font-bold text-green-400'
+        >
+          {showAdvancedOptions ? '▾' : '▸'} ADVANCED OPTIONS
+        </button>
+
+        {showAdvancedOptions && (
+          <div className='grid gap-4 md:grid-cols-2'>
+            {projectFeatureOptions.map((feature) => (
+              <label
+                key={feature.value}
+                className='flex items-center space-x-3 font-mono text-sm text-green-300'
+              >
+                <input
+                  type='checkbox'
+                  checked={
+                    formData.features?.includes(feature.value) ?? false
+                  }
+                  onChange={(e) =>
+                    handleFeatureChange(feature.value, e.target.checked)
+                  }
+                  className='h-4 w-4 rounded border-green-400/30 bg-black/50 text-green-400 focus:ring-green-400/30'
+                />
+                <span>{feature.label}</span>
+              </label>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Contact & Additional Info */}

--- a/src/graphql/generated/graphql.ts
+++ b/src/graphql/generated/graphql.ts
@@ -57,6 +57,7 @@ export type CreateProjectRequestInput = {
   readonly budget?: InputMaybe<Scalars['Float']['input']>;
   readonly contactPreference?: InputMaybe<Scalars['String']['input']>;
   readonly description: Scalars['String']['input'];
+  readonly features?: InputMaybe<ReadonlyArray<ProjectFeature>>;
   readonly projectName: Scalars['String']['input'];
   readonly projectType: ProjectType;
   readonly requirements?: InputMaybe<ProjectRequirementsInput>;
@@ -258,9 +259,23 @@ export type ProjectCollaborator = {
 
 /** Infrastructure feature required by a project */
 export enum ProjectFeature {
+  AdminDashboard = 'AdminDashboard',
+  Analytics = 'Analytics',
   Auth = 'Auth',
+  CmsIntegration = 'CmsIntegration',
+  Consultation = 'Consultation',
+  CustomApi = 'CustomApi',
   Database = 'Database',
-  Email = 'Email'
+  Deployment = 'Deployment',
+  DomainConfig = 'DomainConfig',
+  Email = 'Email',
+  FileUploads = 'FileUploads',
+  PaymentProcessing = 'PaymentProcessing',
+  ProjectManagement = 'ProjectManagement',
+  ResponsiveDesign = 'ResponsiveDesign',
+  Seo = 'Seo',
+  Testing = 'Testing',
+  ThirdPartyIntegrations = 'ThirdPartyIntegrations'
 }
 
 export type ProjectFilter = {
@@ -294,6 +309,7 @@ export type ProjectRequest = {
   readonly contactPreference?: Maybe<Scalars['String']['output']>;
   readonly createdAt: Scalars['String']['output'];
   readonly description: Scalars['String']['output'];
+  readonly features?: Maybe<ReadonlyArray<ProjectFeature>>;
   readonly id: Scalars['ID']['output'];
   readonly projectName: Scalars['String']['output'];
   readonly projectType: ProjectType;
@@ -669,7 +685,7 @@ export type CreateProjectRequestMutationVariables = Exact<{
 }>;
 
 
-export type CreateProjectRequestMutation = { readonly __typename?: 'Mutation', readonly createProjectRequest: { readonly __typename?: 'ProjectRequest', readonly id: string, readonly projectName: string, readonly title?: string | null, readonly description: string, readonly projectType: ProjectType, readonly budget?: number | null, readonly timeline?: string | null, readonly contactPreference?: string | null, readonly additionalInfo?: string | null, readonly status: ProjectStatus, readonly createdAt: string, readonly updatedAt: string, readonly requirements?: { readonly __typename?: 'ProjectRequirements', readonly hasDesign?: boolean | null, readonly needsHosting?: boolean | null, readonly hasDomain?: boolean | null, readonly needsMaintenance?: boolean | null, readonly needsContentCreation?: boolean | null, readonly needsSEO?: boolean | null } | null } };
+export type CreateProjectRequestMutation = { readonly __typename?: 'Mutation', readonly createProjectRequest: { readonly __typename?: 'ProjectRequest', readonly id: string, readonly projectName: string, readonly title?: string | null, readonly description: string, readonly projectType: ProjectType, readonly budget?: number | null, readonly timeline?: string | null, readonly features?: ReadonlyArray<ProjectFeature> | null, readonly contactPreference?: string | null, readonly additionalInfo?: string | null, readonly status: ProjectStatus, readonly createdAt: string, readonly updatedAt: string, readonly requirements?: { readonly __typename?: 'ProjectRequirements', readonly hasDesign?: boolean | null, readonly needsHosting?: boolean | null, readonly hasDomain?: boolean | null, readonly needsMaintenance?: boolean | null, readonly needsContentCreation?: boolean | null, readonly needsSEO?: boolean | null } | null } };
 
 export type ApproveProjectRequestMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -1471,6 +1487,7 @@ export const CreateProjectRequestDocument = gql`
       needsContentCreation
       needsSEO
     }
+    features
     contactPreference
     additionalInfo
     status

--- a/src/graphql/schema/project.ts
+++ b/src/graphql/schema/project.ts
@@ -46,6 +46,20 @@ export enum ProjectFeature {
   Database = 'database',
   Auth = 'auth',
   Email = 'email',
+  AdminDashboard = 'admin_dashboard',
+  PaymentProcessing = 'payment_processing',
+  FileUploads = 'file_uploads',
+  CustomApi = 'custom_api',
+  Deployment = 'deployment',
+  DomainConfig = 'domain_config',
+  Seo = 'seo',
+  CmsIntegration = 'cms_integration',
+  ResponsiveDesign = 'responsive_design',
+  ThirdPartyIntegrations = 'third_party_integrations',
+  Analytics = 'analytics',
+  Testing = 'testing',
+  Consultation = 'consultation',
+  ProjectManagement = 'project_management',
 }
 
 registerEnumType(ProjectStatus, {

--- a/src/graphql/schema/projectRequest.ts
+++ b/src/graphql/schema/projectRequest.ts
@@ -1,6 +1,6 @@
 import { Field, ID, InputType, ObjectType } from 'type-graphql'
 
-import { ProjectStatus, ProjectType } from './project'
+import { ProjectFeature, ProjectStatus, ProjectType } from './project'
 import { User } from './user'
 
 @ObjectType('ProjectRequirements')
@@ -71,6 +71,9 @@ export class ProjectRequest {
   @Field(() => ProjectRequirements, { nullable: true })
   requirements?: ProjectRequirements
 
+  @Field(() => [ProjectFeature], { nullable: true })
+  features?: ProjectFeature[]
+
   @Field(() => String, { nullable: true })
   contactPreference?: string
 
@@ -122,6 +125,9 @@ export class CreateProjectRequestInput {
 
   @Field(() => ProjectRequirementsInput, { nullable: true })
   requirements?: ProjectRequirementsInput
+
+  @Field(() => [ProjectFeature], { nullable: true })
+  features?: ProjectFeature[]
 
   @Field(() => String, { nullable: true })
   contactPreference?: string

--- a/src/libs/featurePricing.test.ts
+++ b/src/libs/featurePricing.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { ProjectFeature } from '@/graphql/schema'
+
+import { featurePricing } from './featurePricing'
+
+describe('featurePricing', () => {
+  it('covers every ProjectFeature enum value', () => {
+    for (const feature of Object.values(ProjectFeature)) {
+      expect(featurePricing[feature]).toBeDefined()
+    }
+  })
+
+  it('gives every entry a label, defaultPrice, and description', () => {
+    for (const pricing of Object.values(featurePricing)) {
+      expect(typeof pricing.label).toBe('string')
+      expect(pricing.label.length).toBeGreaterThan(0)
+      expect(typeof pricing.defaultPrice).toBe('number')
+      expect(pricing.defaultPrice).toBeGreaterThan(0)
+      expect(typeof pricing.description).toBe('string')
+      expect(pricing.description.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('keeps the existing Database, Auth, and Email entries valid', () => {
+    expect(featurePricing[ProjectFeature.Database].defaultPrice).toBe(550)
+    expect(featurePricing[ProjectFeature.Auth].defaultPrice).toBe(350)
+    expect(featurePricing[ProjectFeature.Email].defaultPrice).toBe(225)
+  })
+})

--- a/src/libs/featurePricing.ts
+++ b/src/libs/featurePricing.ts
@@ -1,0 +1,101 @@
+import { ProjectFeature } from '@/graphql/schema'
+
+export type FeaturePricing = {
+  label: string
+  defaultPrice: number
+  description: string
+}
+
+/**
+ * Internal reference data for auto-populating invoice line items (InvoiceService, Phase 3).
+ * Default prices are midpoints of the market-research ranges in docs/INVOICE_BILLING_EPIC.md,
+ * rounded to the nearest $25. Never expose these to clients - only the admin-set per-invoice
+ * price is client-facing.
+ */
+export const featurePricing: Record<ProjectFeature, FeaturePricing> = {
+  [ProjectFeature.Database]: {
+    label: 'Database Design & Setup',
+    defaultPrice: 550,
+    description: 'Schema design, migrations, and database provisioning',
+  },
+  [ProjectFeature.Auth]: {
+    label: 'Authentication System',
+    defaultPrice: 350,
+    description: 'User sign-up, sign-in, and session management',
+  },
+  [ProjectFeature.Email]: {
+    label: 'Email Integration',
+    defaultPrice: 225,
+    description: 'Transactional email delivery setup',
+  },
+  [ProjectFeature.AdminDashboard]: {
+    label: 'Admin Dashboard',
+    defaultPrice: 1000,
+    description: 'Internal dashboard for managing content and users',
+  },
+  [ProjectFeature.PaymentProcessing]: {
+    label: 'Payment Processing',
+    defaultPrice: 550,
+    description: 'Stripe checkout and payment handling',
+  },
+  [ProjectFeature.FileUploads]: {
+    label: 'File Upload System',
+    defaultPrice: 350,
+    description: 'File storage, upload, and retrieval',
+  },
+  [ProjectFeature.CustomApi]: {
+    label: 'Custom API Endpoints',
+    defaultPrice: 400,
+    description: 'Bespoke API endpoints beyond standard CRUD',
+  },
+  [ProjectFeature.Deployment]: {
+    label: 'Deployment & CI/CD Setup',
+    defaultPrice: 250,
+    description: 'Automated build and deployment pipeline',
+  },
+  [ProjectFeature.DomainConfig]: {
+    label: 'Domain Configuration',
+    defaultPrice: 150,
+    description: 'DNS setup and custom domain configuration',
+  },
+  [ProjectFeature.Seo]: {
+    label: 'SEO Setup',
+    defaultPrice: 350,
+    description: 'Metadata, sitemap, and search engine optimization',
+  },
+  [ProjectFeature.CmsIntegration]: {
+    label: 'CMS Integration',
+    defaultPrice: 550,
+    description: 'Content management system setup and integration',
+  },
+  [ProjectFeature.ResponsiveDesign]: {
+    label: 'Mobile-Responsive Design',
+    defaultPrice: 350,
+    description: 'Layouts optimized for mobile and tablet devices',
+  },
+  [ProjectFeature.ThirdPartyIntegrations]: {
+    label: 'Third-Party Integrations',
+    defaultPrice: 400,
+    description: 'Integration with external services and APIs',
+  },
+  [ProjectFeature.Analytics]: {
+    label: 'Analytics Setup',
+    defaultPrice: 225,
+    description: 'Usage tracking and analytics dashboards',
+  },
+  [ProjectFeature.Testing]: {
+    label: 'Testing & QA',
+    defaultPrice: 350,
+    description: 'Automated test coverage and quality assurance',
+  },
+  [ProjectFeature.Consultation]: {
+    label: 'Consultation',
+    defaultPrice: 275,
+    description: 'Technical consultation and planning',
+  },
+  [ProjectFeature.ProjectManagement]: {
+    label: 'Project Management',
+    defaultPrice: 275,
+    description: 'Ongoing project coordination and management',
+  },
+}

--- a/src/models/projects.ts
+++ b/src/models/projects.ts
@@ -38,6 +38,7 @@ export const projectRequests = pgTable(
     budget: decimal('budget', { precision: 10, scale: 2, mode: 'number' }),
     timeline: varchar('timeline', { length: 100 }),
     requirements: json('requirements').$type<ProjectRequirements>(), // Structured requirements data
+    features: json('features').$type<ProjectFeature[]>(),
     contactPreference: varchar('contact_preference', { length: 50 }),
     additionalInfo: text('additional_info'),
     status: projectStatusEnum('status')

--- a/src/services/ProjectRequestService.test.ts
+++ b/src/services/ProjectRequestService.test.ts
@@ -1,7 +1,7 @@
 import { GraphQLError } from 'graphql'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ProjectStatus, ProjectType } from '@/graphql/schema'
+import { ProjectFeature, ProjectStatus, ProjectType } from '@/graphql/schema'
 import { db } from '@/libs/DB'
 import { isAdminRole } from '@/utils'
 
@@ -31,6 +31,7 @@ describe('ProjectRequestService', () => {
     budget: 5000,
     timeline: '3 months',
     requirements: { hasDesign: false },
+    features: null,
     contactPreference: 'EMAIL',
     additionalInfo: 'Additional info',
     status: ProjectStatus.Requested,
@@ -236,6 +237,27 @@ describe('ProjectRequestService', () => {
       expect(result).toEqual(mockProjectRequest)
     })
 
+    it('should persist client-selected features', async () => {
+      const mockValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([mockProjectRequest]),
+      })
+      mockDbInsert.mockReturnValue({ values: mockValues } as any)
+
+      await projectRequestService.createProjectRequest(
+        {
+          ...mockCreateInput,
+          features: [ProjectFeature.Auth, ProjectFeature.PaymentProcessing],
+        },
+        'user-123'
+      )
+
+      expect(mockValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          features: [ProjectFeature.Auth, ProjectFeature.PaymentProcessing],
+        })
+      )
+    })
+
     it('should throw error when creation fails', async () => {
       mockDbInsert.mockReturnValue({
         values: vi.fn().mockReturnValue({
@@ -379,6 +401,91 @@ describe('ProjectRequestService', () => {
 
       expect(mockDbTransaction).toHaveBeenCalled()
       expect(result).toEqual(mockProject)
+    })
+
+    it("should prefer the request's explicit features over project-type defaults", async () => {
+      const inReviewRequest = {
+        ...mockProjectRequest,
+        status: ProjectStatus.InReview,
+        features: [ProjectFeature.PaymentProcessing],
+      }
+      const mockProject = { id: 'project-123', clientId: 'user-123' }
+      const insertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([mockProject]),
+      })
+
+      mockDbQuery.findFirst.mockResolvedValue(inReviewRequest)
+      mockIsAdminRole.mockReturnValue(true)
+
+      mockDbTransaction.mockImplementation(async (callback) => {
+        return callback({
+          update: vi.fn().mockReturnValue({
+            set: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                returning: vi.fn().mockResolvedValue([{ id: 'request-123' }]),
+              }),
+            }),
+          }),
+          insert: vi.fn().mockReturnValue({ values: insertValues }),
+        } as any)
+      })
+
+      await projectRequestService.approveProjectRequest(
+        'request-123',
+        'admin-user',
+        'admin'
+      )
+
+      expect(insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          features: [ProjectFeature.PaymentProcessing],
+        })
+      )
+    })
+
+    it('should fall back to project-type default features when the request has none', async () => {
+      const inReviewRequest = {
+        ...mockProjectRequest,
+        status: ProjectStatus.InReview,
+        projectType: ProjectType.WebApp,
+        features: null,
+      }
+      const mockProject = { id: 'project-123', clientId: 'user-123' }
+      const insertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([mockProject]),
+      })
+
+      mockDbQuery.findFirst.mockResolvedValue(inReviewRequest)
+      mockIsAdminRole.mockReturnValue(true)
+
+      mockDbTransaction.mockImplementation(async (callback) => {
+        return callback({
+          update: vi.fn().mockReturnValue({
+            set: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                returning: vi.fn().mockResolvedValue([{ id: 'request-123' }]),
+              }),
+            }),
+          }),
+          insert: vi.fn().mockReturnValue({ values: insertValues }),
+        } as any)
+      })
+
+      await projectRequestService.approveProjectRequest(
+        'request-123',
+        'admin-user',
+        'admin'
+      )
+
+      expect(insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          features: [
+            ProjectFeature.Database,
+            ProjectFeature.Auth,
+            ProjectFeature.Email,
+          ],
+        })
+      )
     })
 
     it('should throw access denied error for non-admin', async () => {

--- a/src/services/ProjectRequestService.ts
+++ b/src/services/ProjectRequestService.ts
@@ -117,6 +117,7 @@ export class ProjectRequestService {
         budget: input.budget,
         timeline: input.timeline,
         requirements: input.requirements,
+        features: input.features,
         contactPreference: input.contactPreference,
         additionalInfo: input.additionalInfo,
       })
@@ -296,7 +297,10 @@ export class ProjectRequestService {
           projectType: request.projectType,
           budget: request.budget,
           requirements: request.requirements,
-          features: getDefaultFeatures(request.projectType),
+          features:
+            request.features && request.features.length > 0
+              ? request.features
+              : getDefaultFeatures(request.projectType),
           status: ProjectStatus.Approved,
           featured: false,
         })

--- a/src/services/ProjectService.test.ts
+++ b/src/services/ProjectService.test.ts
@@ -1275,6 +1275,7 @@ describe('ProjectService', () => {
         budget: 5000,
         timeline: '3 months',
         requirements: null,
+        features: null,
         contactPreference: 'EMAIL',
         additionalInfo: 'Additional info',
         status: ProjectStatus.Requested,

--- a/src/validations/ProjectRequestValidation.ts
+++ b/src/validations/ProjectRequestValidation.ts
@@ -1,6 +1,6 @@
 import z from 'zod'
 
-import { ProjectType } from '@/graphql/generated/graphql'
+import { ProjectFeature, ProjectType } from '@/graphql/generated/graphql'
 
 // Project request form validation schema
 export const projectRequestSchema = z.object({
@@ -39,6 +39,7 @@ export const projectRequestSchema = z.object({
       needsSEO: z.boolean().optional(),
     })
     .optional(),
+  features: z.array(z.nativeEnum(ProjectFeature)).optional(),
 })
 
 // Infer the TypeScript type from the schema
@@ -64,6 +65,20 @@ export const projectTypeOptions = Object.values(ProjectType).map((value) => ({
 // maintenance -> "Maintenance"
 // consultation -> "Consultation"
 // other -> "Other"
+
+// Feature options for the advanced request options section - labels only, no pricing
+// (pricing is admin-only reference data in src/libs/featurePricing.ts)
+export const projectFeatureOptions = Object.values(ProjectFeature).map(
+  (value) => ({
+    value,
+    label: value
+      .replace(/_/g, ' ') // Replace underscores with spaces
+      .replace(/([A-Z])/g, ' $1') // Add space before capital letters (for camelCase)
+      .replace(/^./, (str) => str.toUpperCase()) // Capitalize first letter
+      .replace(/\s+/g, ' ') // Normalize multiple spaces to single space
+      .trim(), // Remove leading/trailing spaces
+  })
+)
 
 // Contact preference options
 export const contactPreferenceOptions = [


### PR DESCRIPTION
## Summary

Implements task #2 (Phase 1 of docs/INVOICE_BILLING_EPIC.md): expands the `ProjectFeature` enum, adds `featurePricing.ts` reference data, and lets clients optionally pick features in a collapsed "Advanced Options" section of the request form.

- **Enum**: `ProjectFeature` expanded from 3 to 17 values (14 new: AdminDashboard, PaymentProcessing, FileUploads, CustomApi, Deployment, DomainConfig, Seo, CmsIntegration, ResponsiveDesign, ThirdPartyIntegrations, Analytics, Testing, Consultation, ProjectManagement). Existing `Database`/`Auth`/`Email` unchanged.
- **`src/libs/featurePricing.ts`** (path corrected from the doc's `src/lib/` per repo convention): maps every enum value to `{ label, defaultPrice, description }`. Default prices are midpoints of the doc's market-research ranges, rounded to nearest $25. Not imported anywhere yet (that's `InvoiceService`, task #5) — added to `knip.config.ts` ignore list in the meantime.
- **Model**: `project_requests` gets a new nullable `features` json column (mirrors `projects.features`). No Postgres enum needed for `ProjectFeature` itself — it's stored as `json`, same as the existing `projects.features` column (doc discrepancy noted in TASKS.md).
- **GraphQL**: `features` field added to `ProjectRequest` and `CreateProjectRequestInput`.
- **Service**: `createProjectRequest` persists `input.features`; `approveProjectRequest` now prefers the request's explicit `features` over `getDefaultFeatures(projectType)`, falling back when none were selected.
- **UI**: `ProjectRequestForm` gets a collapsed-by-default "▸ ADVANCED OPTIONS" section with one checkbox per feature (`projectFeatureOptions` — labels only, no pricing; `featurePricing.ts` is never imported client-side).

## NEEDS HUMAN
Run `db:migrate` to apply migration `0018_gifted_venom.sql` (adds `project_requests.features` json column).

## Test plan
- [x] `npm run test` — full suite passes (813 tests)
- [x] `npm run check:types` — clean
- [x] `npm run lint` — clean
- [x] `npm run check:deps` (knip) — clean
- [x] `npm run db:generate` — migration generated, not applied
- [x] Added/updated tests for `featurePricing`, `ProjectRequestService`, and `ProjectRequestForm` (advanced options toggle + checkbox behavior)

🤖 Generated with an overnight nightlight session

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Requires a DB migration and changes approval-time feature assignment; billing reference data is added but not exposed to clients.
> 
> **Overview**
> Clients can optionally select **infrastructure features** when submitting a project request via a new collapsed **ADVANCED OPTIONS** section on `ProjectRequestForm` (labels only; no pricing on the client).
> 
> **`ProjectFeature`** grows from 3 to 17 values in GraphQL/schema; optional **`features`** is added on `ProjectRequest` / `CreateProjectRequestInput`, persisted on **`project_requests.features`** (migration `0018_gifted_venom.sql` — must be applied). **`createProjectRequest`** stores submitted features; **`approveProjectRequest`** copies the request’s features onto the new project when any were chosen, otherwise keeps **`getDefaultFeatures(projectType)`**.
> 
> **`featurePricing.ts`** adds admin-only default line-item reference data (not wired to UI yet; ignored in knip). Validation adds optional `features`; API client and tests updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f78dd03d47bdbc0b1a08f71cbc4507367fdc849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->